### PR TITLE
Fix showClear, keyboard navigation in native shadow DOM, support more paper-input APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+demo_components

--- a/demo/index.html
+++ b/demo/index.html
@@ -110,6 +110,22 @@
                 document.getElementById('input-value-source').addEventListener('input', onValueSourceInput);
                 ```
             </mark-down>
+
+            <h4 class="margin-top two">Hidden Clear Button</h4>
+            <paper-autocomplete label="Select State" id="input-hidden-clear" show-clear="false"></paper-autocomplete>
+            <mark-down>
+                ```html
+                <xmp><paper-autocomplete label="Select State" id="input-hidden-clear" show-clear="false"></paper-autocomplete>
+                <paper-input id="input-value-source" label="Type in this paper-input"></paper-input>
+                </xmp>
+                ```
+                ```js
+                HTMLImports.whenReady(function(){
+                   var inputLocal=document.querySelector('#input-hidden-clear');
+                   inputLocal.source=theLocalStatesArray;
+                });
+                ```
+            </mark-down>
             <p></p>
 
             <!--docs-->

--- a/demo/index.html
+++ b/demo/index.html
@@ -75,6 +75,24 @@
                 ```
             </mark-down>
 
+            <h4 class="margin-top two">Support for <code>&lt;paper-input&gt;</code>'s <code>autoValidate</code>, <code>errorMessage</code>, <code>required</code> &amp; <code>validate()</code></h4>
+            <p>Require a truthy value and automatically validate.</p>
+            <paper-autocomplete label="A paper-autocomplete with no suggestions" id="input-validate" no-label-float required auto-validate error-message="Must not be empty!"></paper-autocomplete>
+            <button id="button-validate">Validate!</button>
+            <mark-down>
+                ```html
+                <xmp><paper-autocomplete label="A paper-autocomplete with no suggestions" id="input-validate" no-label-float required auto-validate error-message="Must not be empty!"></paper-autocomplete>
+                <button id="button-validate">Validate!</button>
+                </xmp>
+                ```
+                ```js
+                function onValidateButtonClick(){
+                  document.getElementById('input-validate').validate();
+                }
+                document.getElementById('button-validate').addEventListener('click', onValidateButtonClick);
+                ```
+            </mark-down>
+
             <p></p>
 
             <!--docs-->
@@ -84,12 +102,48 @@
                 <h4>Properties</h4>
                 <hr>
                 <flex-box class="space-between full-width row">
+                    <span>autoValidate</span>
+                    <flex-box class="column">
+                        <span>{Boolean}</span>
+                        <span>Set to true to auto-validate the input value</span>
+                    </flex-box>
+                    <span>default:false</span>
+                </flex-box>
+                <hr>
+                <flex-box class="space-between full-width row">
+                    <span>errorMessage</span>
+                    <flex-box class="column">
+                        <span>{String}</span>
+                        <span>The error message to display when the input is invalid</span>
+                    </flex-box>
+                    <span>default:''</span>
+                </flex-box>
+                <hr>
+                <flex-box class="space-between full-width row">
                     <span>label</span>
                     <flex-box class="column">
                         <span>{String}</span>
                         <span>The text input placeholder</span>
                     </flex-box>
                     <span>default:''</span>
+                </flex-box>
+                <hr>
+                <flex-box class="space-between full-width row">
+                    <span>noLabelFloat</span>
+                    <flex-box class="column">
+                        <span>{Boolean}</span>
+                        <span>Set to true to disable the floating label</span>
+                    </flex-box>
+                    <span>default:false</span>
+                </flex-box>
+                <hr>
+                <flex-box class="space-between full-width row">
+                    <span>required</span>
+                    <flex-box class="column">
+                        <span>{Boolean}</span>
+                        <span>Set to true to mark the input as required</span>
+                    </flex-box>
+                    <span>default:false</span>
                 </flex-box>
                 <hr>
                 <flex-box class="space-between full-width row">
@@ -116,7 +170,7 @@
                         <span>{Boolean}</span>
                         <span>Show the clear X button</span>
                     </flex-box>
-                    <span>default:true</span>
+                    <span>default:false</span>
                 </flex-box>
                 <hr>
                 <flex-box class="space-between full-width row">
@@ -184,6 +238,15 @@
                         <span>sets the component's current suggestions</span>
                     </flex-box>
                     <span>params:{Array}</span>
+                </flex-box>
+                <hr>
+                <flex-box class="space-between full-width row">
+                    <span>validate</span>
+                    <flex-box class="column">
+                        <span>{Boolean}</span>
+                        <span>Validates the input element and sets an error style if needed</span>
+                    </flex-box>
+                    <span>params:none</span>
                 </flex-box>
             </section>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -93,6 +93,23 @@
                 ```
             </mark-down>
 
+            <h4 class="margin-top two"><code>value</code> Assignment Support</h4>
+            <p>Type in the paper input to and see its value set in the paper-autocomplete.</p>
+            <paper-autocomplete label="A paper-autocomplete with no suggestions" id="input-value"></paper-autocomplete>
+            <paper-input id="input-value-source" label="Type in this paper-input"></paper-input>
+            <mark-down>
+                ```html
+                <xmp><paper-autocomplete label="A paper-autocomplete with no suggestions" id="input-value"></paper-autocomplete>
+                <paper-input id="input-value-source" label="Type in this paper-input"></paper-input>
+                </xmp>
+                ```
+                ```js
+                function onValueSourceInput(evt){
+                  document.getElementById('input-value').value = evt.target.value;
+                }
+                document.getElementById('input-value-source').addEventListener('input', onValueSourceInput);
+                ```
+            </mark-down>
             <p></p>
 
             <!--docs-->

--- a/demo/js/app.js
+++ b/demo/js/app.js
@@ -6,7 +6,9 @@
         localBind();
         document.addEventListener('autocomplete.selected',onSelect);
         document.addEventListener('autocomplete.change',onChange)
+
         document.getElementById('button-validate').addEventListener('click', onValidateButtonClick);
+        document.getElementById('input-value-source').addEventListener('input', onValueSourceInput);
     });
 
     function localBind(){
@@ -256,6 +258,10 @@
 
     function onValidateButtonClick(){
       document.getElementById('input-validate').validate();
+    }
+
+    function onValueSourceInput(evt){
+      document.getElementById('input-value').value = evt.target.value;
     }
 
     function getToast(){

--- a/demo/js/app.js
+++ b/demo/js/app.js
@@ -254,6 +254,9 @@
 
         var inputLocal=document.querySelector('#input-local');
         inputLocal.source=states;
+
+        var inputHiddenClear=document.querySelector('#input-hidden-clear');
+        inputHiddenClear.source=states;
     }
 
     function onValidateButtonClick(){

--- a/demo/js/app.js
+++ b/demo/js/app.js
@@ -6,6 +6,7 @@
         localBind();
         document.addEventListener('autocomplete.selected',onSelect);
         document.addEventListener('autocomplete.change',onChange)
+        document.getElementById('button-validate').addEventListener('click', onValidateButtonClick);
     });
 
     function localBind(){
@@ -251,6 +252,10 @@
 
         var inputLocal=document.querySelector('#input-local');
         inputLocal.source=states;
+    }
+
+    function onValidateButtonClick(){
+      document.getElementById('input-validate').validate();
     }
 
     function getToast(){

--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -362,7 +362,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     _getItems:function(){
-      return this.querySelectorAll('paper-item');
+      return this.$.suggestionsWrapper.querySelectorAll('paper-item');
     },
 
     _emptyItems:function(){
@@ -415,8 +415,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if(viewIndex >= this._maxViewableItems){
         this._scrollIndex++;
         var scrollTop=(this._scrollIndex * this._itemHeight);
-        var paperMaterial=this.querySelector('paper-material');
-        paperMaterial.scrollTop=scrollTop;
+        this.$.suggestionsWrapper.scrollTop=scrollTop;
       }
     },
 
@@ -425,8 +424,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if(viewIndex < 0){
         this._scrollIndex--;
         var scrollTop=(this._scrollIndex * this._itemHeight);
-        var paperMaterial=this.querySelector('paper-material');
-        paperMaterial.scrollTop=scrollTop;
+        this.$.suggestionsWrapper.scrollTop=scrollTop;
       }
     },
 

--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -58,10 +58,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       cursor:pointer;
     }
 
-    paper-item.paper-item-0 {
-      min-height: 36px;
-    }
-
     paper-item.active{
       background:#eee;
       color:#333;
@@ -73,6 +69,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     :host {
       --paper-input-container-focus-color: #2196f3;
+      --paper-item-min-height: 36px;
     }
 
   </style>

--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -327,7 +327,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           if (this._suggestions.length > 0) {
             this.$.suggestionsWrapper.style.display = 'block';
-          }else{            
+          }else{
             this._hideSuggestionsWrapper();
           }
         }

--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -79,7 +79,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <template>
     <div class="input-wrapper">
-      <paper-input id="input" label="[[label]]" no-label-float="[[noLabelFloat]]" on-keyup="_onKeypress" disabled="[[disabled]]" auto-validate$="[[autoValidate]]" error-message$="[[errorMessage]]" required$="[[required]]"></paper-input>
+      <paper-input id="input" label="[[label]]" no-label-float="[[noLabelFloat]]" on-keyup="_onKeypress" disabled="[[disabled]]" auto-validate$="[[autoValidate]]" error-message$="[[errorMessage]]" required$="[[required]]" value="{{value}}"></paper-input>
       <paper-icon-button id="clear" icon="clear" on-click="_clear"></paper-icon-button>
     </div>
     <paper-material elevation="1" id="suggestionsWrapper">

--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -79,7 +79,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <template>
     <div class="input-wrapper">
-      <paper-input id="input" label="{{label}}" no-label-float="{{noLabelFloat}}" on-keyup="_onKeypress" disabled="{{disabled}}"></paper-input>
+      <paper-input id="input" label="[[label]]" no-label-float="[[noLabelFloat]]" on-keyup="_onKeypress" disabled="[[disabled]]" auto-validate$="[[autoValidate]]" error-message$="[[errorMessage]]" required$="[[required]]"></paper-input>
       <paper-icon-button id="clear" icon="clear" on-click="_clear"></paper-icon-button>
     </div>
     <paper-material elevation="1" id="suggestionsWrapper">
@@ -101,6 +101,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     properties: {
 
       /**
+       * `autoValidate` Set to true to auto-validate the input value.
+       */
+      autoValidate: {
+        type: Boolean,
+        value: false
+      },
+
+      /**
+       * `errorMessage` The error message to display when the input is invalid.
+       */
+      errorMessage: {
+        type: String,
+      },
+
+      /**
        * `label` Text to display as the input label
        */
       label: String,
@@ -109,6 +124,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * `noLabelFloat` Set to true to disable the floating label.
        */
       noLabelFloat:{
+        type: Boolean,
+        value: false
+      },
+
+      /**
+       * `required` Set to true to mark the input as required.
+       */
+      required: {
         type: Boolean,
         value: false
       },
@@ -466,6 +489,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     suggestions: function (arr) {
       this._bindSuggestions(arr);
+    },
+
+    validate: function(){
+      return this.$.input.validate();
     }
 
   });

--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -441,6 +441,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this._keyup(event);
       }else if(which===13){
         this._keyenter();
+      }else if (which===27){
+        this._hideSuggestionsWrapper();
       }else{
         this._handleSuggestions(event);
       }
@@ -457,6 +459,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         value: this.value
       };
       this._fireEvent(option,'blur');
+
+      var self = this;
+      setTimeout(function() {
+        self._hideSuggestionsWrapper();
+      }, 150);
     },
 
     _onFocus: function (event) {

--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -285,7 +285,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this._suggestions = arr;
         this._currentIndex = -1;
         this._scrollIndex = 0;
-        this.$.clear.style.display = 'block';
+
+        if(this.showClear){
+          this.$.clear.style.display = 'block';
+        }
         this.$.suggestionsWrapper.style.display = 'block';
       } else {
         this.$.clear.style.display = 'none';
@@ -302,8 +305,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if(value && value.length >=minLength){
         value = value.toLowerCase();
 
-        // Shows the clear button.
-        this.$.clear.style.display = 'block';
+        if(this.showClear){
+          // Shows the clear button.
+          this.$.clear.style.display = 'block';
+        }
 
         // Search for the word in the source properties.
         if(this.source && this.source.length > 0){


### PR DESCRIPTION
Thanks for this element! I encountered a few issues when trying to swap it in place of `<paper-input>`, and thought my fixes/changes may be useful to have upstream:
1. The `autoValidate`, `errorMessage` and `required` `<paper-input>` properties are now exposed, as is the `<paper-input>`'s `validate()` function.
2. The internal `<paper-input>`'s value is now bound two-way, so that it can get set programmatically (eg. when initialising an input).
3. The dropdown is now hidden when the input loses focus (eg. the user clicks on another element) or when the Escape key is pressed, to improve usability.
4. `showClear`'s default value is `false`, so I corrected the demo page, which said it was true, and fixed the clear button appearing when the dropdown was visible even when `showClear` is false.
5. Keyboard navigation was broken for when Polymer is configured to use native shadow DOM, so I fixed that.

I also took the liberty of making some existing two-way data binding one-way, as the internal-to-external binding direction would never be used, and I added sections to the demo page for the new functionality I added.
