### PR TITLE
Integrating demo in master following Polymer standard convention

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+
+# Change these settings to your own preference
+indent_style = space
+indent_size = 2
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/bower.json
+++ b/bower.json
@@ -35,6 +35,10 @@
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-    "web-component-tester": "*"
+    "web-component-tester": "*",
+    "iron-demo-helpers": "^1.2.5",
+    "paper-toast": "^1.3.0",
+    "elliptical-sass": "^1.2.29",
+    "css-docs": "https://github.com/ellipticaljs/css-docs.git#^1.0.3"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -39,6 +39,6 @@
     "iron-demo-helpers": "^1.2.5",
     "paper-toast": "^1.3.0",
     "elliptical-sass": "^1.2.29",
-    "css-docs": "https://github.com/ellipticaljs/css-docs.git#^1.0.3"
+    "css-docs": "^1.0.3"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "paper-autocomplete",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "authors": [
     "S. Francis",
     "Rodolfo Oviedo <rodo1111@gmail.com>",

--- a/demo/demo.css
+++ b/demo/demo.css
@@ -1,0 +1,12 @@
+paper-autocomplete {
+  width: 450px;
+  max-width: 100%;
+}
+
+.bold {
+  font-weight: 500;
+}
+
+blockquote {
+  font-family: RobotoDraft;
+}

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,182 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+  <title>paper-autocomplete demo</title>
+  <script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+
+  <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
+  <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
+  <link rel="import" href="../../paper-toast/paper-toast.html">
+  <link rel="import" href="../../elliptical-sass/elliptical-sass.html">
+  <link rel="import" href="../../css-docs/css-docs.html">
+  <link rel="import" href="../paper-autocomplete.html">
+
+  <link rel="stylesheet" href="demo.css">
+
+  <style is="custom-style" include="demo-pages-shared-styles">
+    .vertical-section-container {
+      max-width: 600px;
+    }
+  </style>
+</head>
+
+<body unresolved>
+
+<div class="vertical-section-container centered">
+  <h3>Local Data-Source Binding</h3>
+  <p>
+    Directly bind a local array to paper-autocomplete. The component internally will filter suggestions based on the
+    component attribute settings.
+  </p>
+
+  <blockquote class="info">
+    <span class="bold">LOCAL DATA BINDING</span><br>
+    <div>
+      The component internally remaps the passed array to the template binding array (which will be an array of objects
+      with a `text` and `value` properties). The passed array can be a simple array of strings.
+    </div>
+    <br>
+    <div>
+      Public properties, `textProperty` and `valueProperty`, can be declaratively set in the element attributes,
+      allowing to bind an arbitrary object array to the component's <span class="bold">source</span> property.
+    </div>
+  </blockquote>
+
+  <demo-snippet>
+    <template is="dom-bind">
+
+      <paper-autocomplete label="Select State" id="input-local" no-label-float="true"></paper-autocomplete>
+
+      <script>
+        var states = [
+          {"text": "Alabama", "value": "AL"},
+          {"text": "Alaska", "value": "AK"},
+          {"text": "American Samoa", "value": "AS"},
+          {"text": "Arizona", "value": "AZ"},
+          {"text": "Arkansas", "value": "AR"},
+          {"text": "California", "value": "CA"},
+          {"text": "Colorado", "value": "CO"},
+          {"text": "Connecticut", "value": "CT"},
+          {"text": "Delaware", "value": "DE"},
+          {"text": "District Of Columbia", "value": "DC"},
+          {"text": "Federated States Of Micronesia", "value": "FM"},
+          {"text": "Florida", "value": "FL"},
+          {"text": "Georgia", "value": "GA"},
+          {"text": "Guam", "value": "GU"},
+          {"text": "Hawaii", "value": "HI"},
+          {"text": "Idaho", "value": "ID"},
+          {"text": "Illinois", "value": "IL"},
+          {"text": "Indiana", "value": "IN"},
+          {"text": "Iowa", "value": "IA"},
+          {"text": "Kansas", "value": "KS"},
+          {"text": "Kentucky", "value": "KY"},
+          {"text": "Louisiana", "value": "LA"},
+          {"text": "Maine", "value": "ME"},
+          {"text": "Marshall Islands", "value": "MH"},
+          {"text": "Maryland", "value": "MD"},
+          {"text": "Massachusetts", "value": "MA"},
+          {"text": "Michigan", "value": "MI"},
+          {"text": "Minnesota", "value": "MN"},
+          {"text": "Mississippi", "value": "MS"},
+          {"text": "Missouri", "value": "MO"},
+          {"text": "Montana", "value": "MT"},
+          {"text": "Nebraska", "value": "NE"},
+          {"text": "Nevada", "value": "NV"},
+          {"text": "New Hampshire", "value": "NH"},
+          {"text": "New Jersey", "value": "NJ"},
+          {"text": "New Mexico", "value": "NM"},
+          {"text": "New York", "value": "NY"},
+          {"text": "North Carolina", "value": "NC"},
+          {"text": "North Dakota", "value": "ND"},
+          {"text": "Northern Mariana Islands", "value": "MP"},
+          {"text": "Ohio", "value": "OH"},
+          {"text": "Oklahoma", "value": "OK"},
+          {"text": "Oregon", "value": "OR"},
+          {"text": "Palau", "value": "PW"},
+          {"text": "Pennsylvania", "value": "PA"},
+          {"text": "Puerto Rico", "value": "PR"},
+          {"text": "Rhode Island", "value": "RI"},
+          {"text": "South Carolina", "value": "SC"},
+          {"text": "South Dakota", "value": "SD"},
+          {"text": "Tennessee", "value": "TN"},
+          {"text": "Texas", "value": "TX"},
+          {"text": "Utah", "value": "UT"},
+          {"text": "Vermont", "value": "VT"},
+          {"text": "Virgin Islands", "value": "VI"},
+          {"text": "Virginia", "value": "VA"},
+          {"text": "Washington", "value": "WA"},
+          {"text": "West Virginia", "value": "WV"},
+          {"text": "Wisconsin", "value": "WI"},
+          {"text": "Wyoming", "value": "WY"}
+        ];
+
+        var inputLocal = document.querySelector('#input-local');
+
+        inputLocal.source = states;
+      </script>
+    </template>
+  </demo-snippet>
+
+  <h3>Remote Data-Source Binding</h3>
+  <p>
+    Remote bind to the github user api. Remote data binding delegates the responsibility of filtering the data source to
+    the calling app. Set a listener for the <span class="bold">autocomplete.change</span> event and pass the suggestions
+    back to the component. The change event is fired based on the <span class="bold">min-length</span> attribute
+    setting.
+  </p>
+
+  <blockquote class="warning">
+    <span class="bold">REMOTE DATA BINDING</span><br>
+    <div>
+      The filtered suggestions is expected to be mapped to an array of text/value pairs before being passed to the
+      component.
+    </div>
+  </blockquote>
+
+  <demo-snippet>
+    <template is="dom-bind">
+
+      <paper-autocomplete label="Select User"
+                          id="input-remote"
+                          remote-source="true"
+                          min-length="2"></paper-autocomplete>
+
+      <script>
+        var paperToast = document.querySelector('paper-toast');
+
+        document.addEventListener('autocomplete-selected', onSelect);
+        document.addEventListener('autocomplete-change', onChange);
+
+        function onSelect(event) {
+          var selected = event.detail.text;
+          paperToast.text = 'Selected: ' + selected;
+          paperToast.show();
+        }
+
+        function onChange(event) {
+          var input = document.querySelector('#input-remote');
+          var search = event.detail.option.text;
+          var url = 'https://api.github.com/search/users?q=' + search + '+in:login';
+          var req = new XMLHttpRequest();
+          req.open('GET', encodeURI(url));
+          req.onload = function () {
+            if (req.status === 200) {
+              var data = JSON.parse(req.response);
+              var arr = data.items.map(function (obj) {
+                return {text: obj.login, value: obj.login};
+              });
+              input.suggestions(arr);
+            }
+          };
+          req.send();
+        }
+      </script>
+    </template>
+  </demo-snippet>
+</div>
+
+<paper-toast></paper-toast>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Material Design autocomplete component.",
   "version": "1.1.6",
   "author": "S. Francis <sfrancis@misinteractive.com>",
-  "contributors":[
+  "contributors": [
     "Rodolfo Oviedo <rodo1111@gmail.com>",
     "Alfonso Aguilar <laltfuns@gmail.com>",
     "Oliver Hamlet <oliver.hamlet@gmail.com>",
@@ -17,12 +17,17 @@
     "type": "git",
     "url": "https://github.com/ellipticaljs/paper-autocomplete.git"
   },
+  "scripts": {
+    "serve": "polymer serve",
+    "postinstall": "bower i"
+  },
   "devDependencies": {
+    "fs-extra": "^0.8.1",
     "gulp": "^3.8.7",
-    "gulp-util": "^2.2.14",
     "gulp-concat": "^2.2.0",
     "gulp-tap": "^0.1.1",
-    "fs-extra": "^0.8.1",
-    "gulp-uglify": "^0.2.1"
+    "gulp-uglify": "^0.2.1",
+    "gulp-util": "^2.2.14",
+    "polymer-cli": "^0.16.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "paper-autocomplete",
   "description": "Material Design autocomplete component.",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "author": "S. Francis <sfrancis@misinteractive.com>",
   "contributors": [
     "Rodolfo Oviedo <rodo1111@gmail.com>",

--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -16,6 +16,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../paper-ripple/paper-ripple.html">
 <link rel="import" href="../paper-material/paper-material.html">
 
+<!--
+  `paper-autocomplete`
+
+  TODO: more coming
+
+  ### Styling
+
+  `<paper-autocomplete>` provides the following custom properties and mixins
+  for styling:
+
+  Custom property | Description | Default
+  ----------------|-------------|----------
+  `--paper-input-container-focus-color` | sets the components input container focus color | #2196f3
+  `--paper-item-min-height` | paper item min height | `{}`
+
+  @demo demo/index.html
+-->
 
 <dom-module id="paper-autocomplete">
   <style>
@@ -24,7 +41,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       box-sizing: border-box;
       position: relative;
     }
-    
+
     .input-wrapper {
       @apply(--layout-horizontal);
     }
@@ -51,7 +68,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       color:#333;
       cursor:pointer;
     }
-    
+
     paper-item.active{
       background:#eee;
       color:#333;
@@ -442,7 +459,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         text: this.text,
         value: this.value
       };
-      
+
       this._fireEvent(option,'blur');
       setTimeout(function() {
         self.$.clear.style.display = 'none';

--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -173,7 +173,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       /**
        * The current/selected text of the input
-       * @default ""
        */
       text:{
         type:String,
@@ -183,7 +182,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       /**
        * Disable showing the clear X button
-       * @default false
        */
       disableShowClear:{
         type:Boolean,

--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -19,7 +19,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <!--
   `paper-autocomplete`
 
-  TODO: more coming
+  Paper Input Autocomplete field to offer a type-ahead functionality for Polymer v1.0.0 or greater.
+
+  paper-autocomplete extends earlier efforts such as this (https://github.com/rodo1111/paper-input-autocomplete)
+  to provide keyboard support, remote binding and results scrolling.
 
   ### Styling
 
@@ -117,10 +120,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       errorMessage: {
         type: String,
       },
+
       /**
        * `label` Text to display as the input label
        */
       label: String,
+
       /**
        * `noLabelFloat` Set to true to disable the floating label.
        */
@@ -141,17 +146,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * `source` Array of objects with the options to execute the autocomplete feature
        */
       source: Array,
+
       /**
-       *
+       * Property of local datasource to as the text property
        */
       textProperty:{
         type:String,
         value:'text'
       },
+
+      /**
+       * Property of local datasource to as the value property
+       */
       valueProperty:{
         type:String,
         value:'value'
       },
+
       /**
        * `value` Selected object from the suggestions
        */
@@ -160,30 +171,51 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         notify: true
       },
 
+      /**
+       * The current/selected text of the input
+       * @default ""
+       */
       text:{
         type:String,
-        notify:true
+        notify:true,
+        value:''
       },
 
+      /**
+       * Disable showing the clear X button
+       * @default false
+       */
       disableShowClear:{
         type:Boolean,
         value:false
       },
 
+      /**
+       * Binds to a remote data source
+       */
       remoteSource:{
         type: Boolean,
         value:false
       },
 
+      /**
+       * Event type separator
+       */
       eventNamespace:{
          type:String,
          value:'-'
       },
 
+      /**
+       * Minimum length to trigger suggestions
+       */
       minLength:{
         value:1
       },
 
+      /**
+       * Indicates if shadow dom is used
+       */
       useShadowDom:{
         type:Boolean,
         value:false
@@ -428,7 +460,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         paperMaterial.scrollTop=scrollTop;
       }
     },
-
     _fireEvent: function (option, evt) {
       var id=this._getId();
       var event='autocomplete' + this.eventNamespace + evt;
@@ -476,10 +507,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     /* public */
+    /**
+     * Gets the current value of the input
+     * @returns {String}
+     */
     getValue : function() {
       return this.value;
     },
 
+    /**
+     * Gets the current text/value option of the input
+     * @returns {Object}
+     */
     getOption:function(){
       return {
         text: this.text,
@@ -487,39 +526,66 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       };
     },
 
+    /**
+     * Sets the current text/value option of the input
+     * @param {Object} option
+     */
     setOption:function(option){
        this.text=option.text;
        this.value=option.value;
     },
 
+    /**
+     * Disables the input
+     */
     disable: function(){
       this.disabled=true;
       this.$.input.disabled=true;
     },
 
+    /**
+     * Enables the input
+     */
     enable:function(){
       this.disabled=false;
       this.$.input.disabled=false;
     },
 
+    /**
+     * Sets the component's current suggestions
+     * @param {Array} arr
+     */
     suggestions: function (arr) {
       this._bindSuggestions(arr);
     },
 
+    /**
+     * Validates the input
+     * @returns {Boolean}
+     */
     validate: function(){
       return this.$.input.validate();
     },
 
+    /**
+     * Clears the current input
+     */
     clear:function(){
       this._value='';
       this._text='';
       this._clear();
     },
 
+    /**
+     * Resets the current input
+     */
     reset:function(){
       this._clear();
     },
 
+    /**
+     * Hides the suggestions popup
+     */
     hideSuggestions:function(){
       var self=this;
       setTimeout(function() {
@@ -528,7 +594,54 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }, 300);
     }
 
+    /**
+     * Fired when a selection is made
+     *
+     * @event autocomplete-selected
+     * @param {String} id
+     * @param {String} text
+     * @param {Element} target
+     * @param {Object} option
+     */
 
+    /**
+     * Fired on input change
+     *
+     * @event autocomplete-change
+     * @param {String} id
+     * @param {String} text
+     * @param {Element} target
+     * @param {Object} option
+     */
 
+    /**
+     * Fired on input focus
+     *
+     * @event autocomplete-focus
+     * @param {String} id
+     * @param {String} text
+     * @param {Element} target
+     * @param {Object} option
+     */
+
+    /**
+     * Fired on input blur
+     *
+     * @event autocomplete-blur
+     * @param {String} id
+     * @param {String} text
+     * @param {Element} target
+     * @param {Object} option
+     */
+
+    /**
+     * Fired on input reset/clear
+     *
+     * @event autocomplete-reset-blur
+     * @param {String} id
+     * @param {String} text
+     * @param {Element} target
+     * @param {Object} option
+     */
   });
 </script>


### PR DESCRIPTION
I have move the content of the demo from the `gh-pages` branch into a new html file in the demo page. So now when you serve the component with `polymer serve` you will see the DEMO link and you will see examples.

I tried to maintain as close as possible the content from (http://ellipticaljs.github.io/paper-autocomplete/), even trying to maintain the styles.

There is a few things that need to be done: the examples page contains more documentation: there is no information about events, methods, etc. I am planning to continue working on that, but I would prefer to get some feedback first. Kind of know if maintainers of the project agree with this change before I waste more time.

As a plus, I also added `.editorconfig` that I hope you don't mind. It is very useful for people like me who worked in different projects all the time.
