### PR TITLE
Make the component Accessible

### DIFF
--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -92,23 +92,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </style>
 
   <template>
-    <div class="input-wrapper" role="combobox" aria-haspopup="true" aria-owns="suggestionsWrapper"
-         aria-expanded$="[[_isSuggestionsOpened]]">
-
-      <!-- For accessibility, it is needed to have a label or aria-label. Label is preferred -->
-      <label for="input" class="sr-only">[[label]]</label>
-
+    <div class="input-wrapper">
       <paper-input id="input" label="[[label]]" no-label-float="[[noLabelFloat]]" on-keyup="_onKeypress"
                    disabled="{{disabled}}" auto-validate$="[[autoValidate]]" error-message$="[[errorMessage]]"
                    required$="[[required]]" value="{{text}}" allowed-pattern="[[allowedPattern]]" pattern="[[pattern]]"
-
-                   role="textbox" aria-autocomplete="list"
-                   aria-multiline="false" aria-activedescendant$="[[_idElementHighlighted]]"
-                   aria-disabled$="[[disabled]]"></paper-input>
+                   role="combobox" tabindex="0" aria-autocomplete="list" aria-multiline="false"
+                   aria-activedescendant$="[[_idElementHighlighted]]" aria-disabled$="[[disabled]]"
+                   aria-controls="selectedStatus suggestionsWrapper" aria-haspopup="true" aria-owns="suggestionsWrapper"
+                   aria-expanded$="[[_isSuggestionsOpened]]"></paper-input>
       <paper-icon-button id="clear" icon="clear" on-click="_clear"></paper-icon-button>
 
       <!-- to announce current selection to screen reader -->
-      <span role="status" class="sr-only">[[_textOfHighlightedElement]]</span>
+      <span id="selectedStatus" role="region" aria-live="assertive" class="sr-only" tabindex="-1">
+        [[_textOfHighlightedElement]]
+      </span>
     </div>
     <paper-material elevation="1" id="suggestionsWrapper" role="listbox">
       <template is="dom-repeat" items="{{_suggestions}}">
@@ -137,7 +134,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * `errorMessage` The error message to display when the input is invalid.
        */
       errorMessage: {
-        type: String,
+        type: String
       },
 
       /**
@@ -294,8 +291,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * Text value of the current highlighted value to be announce to the screen reader
        */
       _textOfHighlightedElement: {
-        type: String,
-        computed: 'computeFullName(first, last)'
+        type: String
       },
 
       /**

--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -84,16 +84,35 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       --paper-input-container-focus-color: #2196f3;
       --paper-item-min-height: 36px;
     }
+
+    .sr-only {
+      position: absolute;
+      clip: rect(1px, 1px, 1px, 1px);
+    }
   </style>
 
   <template>
-    <div class="input-wrapper">
-      <paper-input id="input" label="[[label]]" allowed-pattern="[[allowedPattern]]" pattern="[[pattern]]"  no-label-float="[[noLabelFloat]]" on-keyup="_onKeypress" disabled="{{disabled}}" auto-validate$="[[autoValidate]]" error-message$="[[errorMessage]]" required$="[[required]]" value="{{text}}"></paper-input>
+    <div class="input-wrapper" role="combobox" aria-haspopup="true" aria-owns="suggestionsWrapper"
+         aria-expanded$="[[_isSuggestionsOpened]]">
+
+      <!-- For accessibility, it is needed to have a label or aria-label. Label is preferred -->
+      <label for="input" class="sr-only">[[label]]</label>
+
+      <paper-input id="input" label="[[label]]" no-label-float="[[noLabelFloat]]" on-keyup="_onKeypress"
+                   disabled="{{disabled}}" auto-validate$="[[autoValidate]]" error-message$="[[errorMessage]]"
+                   required$="[[required]]" value="{{text}}" allowed-pattern="[[allowedPattern]]" pattern="[[pattern]]"
+
+                   role="textbox" aria-autocomplete="list"
+                   aria-multiline="false" aria-activedescendant$="[[_idElementHighlighted]]"
+                   aria-disabled$="[[disabled]]"></paper-input>
       <paper-icon-button id="clear" icon="clear" on-click="_clear"></paper-icon-button>
+
+      <!-- to announce current selection to screen reader -->
+      <span role="status" class="sr-only">[[_textOfHighlightedElement]]</span>
     </div>
-    <paper-material elevation="1" id="suggestionsWrapper">
+    <paper-material elevation="1" id="suggestionsWrapper" role="listbox">
       <template is="dom-repeat" items="{{_suggestions}}">
-        <paper-item on-click="_onSelect">
+        <paper-item on-click="_onSelect" id$="[[_getSuggestionId(index)]]" role="option" aria-selected="false">
           <div>{{item.text}}</div>
           <paper-ripple></paper-ripple>
         </paper-item>
@@ -251,6 +270,40 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
       _text:{
         value:undefined
+      },
+
+      /**
+       * This value is used as a base to generate unique individual ids that need to be added to each suggestion for
+       * accessibility reasons.
+       */
+      _idItemSeed: {
+        type: String,
+        value: 'aria-' + new Date().getTime() + '-' + (Math.floor(Math.random() * 1000)),
+        readOnly: true
+      },
+
+      /**
+       * Id of the DOM element currently highlighted
+       */
+      _idElementHighlighted: {
+        type: String,
+        value: ''
+      },
+
+      /**
+       * Text value of the current highlighted value to be announce to the screen reader
+       */
+      _textOfHighlightedElement: {
+        type: String,
+        computed: 'computeFullName(first, last)'
+      },
+
+      /**
+       * `true` if the suggestions list is opened, `false otherwise`
+       */
+      _isSuggestionsOpened: {
+        type: Boolean,
+        value: false
       }
     },
     // Element Lifecycle
@@ -297,8 +350,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     /**
      * Hide the suggestions wrapper
      */
+    _showSuggestionsWrapper: function() {
+      this.$.suggestionsWrapper.style.display = 'block';
+      this._isSuggestionsOpened = true;
+    },
+
+    /**
+     * Hide the suggestions wrapper
+     */
     _hideSuggestionsWrapper: function() {
       this.$.suggestionsWrapper.style.display = 'none';
+      this._isSuggestionsOpened = false;
+      this._idElementHighlighted = '';
+      this._textOfHighlightedElement = '';
     },
 
     _handleSuggestions:function(event){
@@ -326,7 +390,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this._currentIndex = -1;
         this._scrollIndex = 0;
         if(!this.disableShowClear) this.$.clear.style.display = 'block';
-        this.$.suggestionsWrapper.style.display = 'block';
+        this._showSuggestionsWrapper();
       } else {
         this.$.clear.style.display = 'none';
         this._suggestions = [];
@@ -362,9 +426,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             }
           }
 
-          if (this._suggestions.length > 0) this.$.suggestionsWrapper.style.display = 'block';
-          else this._hideSuggestionsWrapper();
-
+          if (this._suggestions.length > 0) {
+            this._showSuggestionsWrapper();
+          }else{
+            this._hideSuggestionsWrapper();
+          }
         }
       }else{
         this.$.clear.style.display = 'none';
@@ -407,6 +473,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _removeActive:function(items){
       for(var i=0;i<items.length;i++){
         items[i].classList.remove('active');
+        items[i].setAttribute('aria-selected', "false");
       }
     },
 
@@ -418,6 +485,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this._removeActive(items);
         this._currentIndex++;
         items[this._currentIndex].classList.add('active');
+        items[this._currentIndex].setAttribute('aria-selected', "true");
+        this._idElementHighlighted = items[this._currentIndex].id;
+        this._textOfHighlightedElement = this._suggestions[this._currentIndex].text;
         this._scrollDown();
       }
     },
@@ -428,6 +498,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this._removeActive(items);
         this._currentIndex--;
         items[this._currentIndex].classList.add('active');
+        items[this._currentIndex].setAttribute('aria-selected', "true");
+        this._idElementHighlighted = items[this._currentIndex].id;
+        this._textOfHighlightedElement = this._suggestions[this._currentIndex].text;
         this._scrollUp();
       }
     },
@@ -590,6 +663,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         self.$.clear.style.display = 'none';
         self._hideSuggestionsWrapper();
       }, 300);
+    },
+
+    /**
+     * Generate a suggestion id for a certain index
+     * @param {number} index Position of the element in the suggestions list
+     * @returns {string} a unique id based on the _idItemSeed and the position of that element in the suggestions popup
+     * @private
+     */
+    _getSuggestionId: function (index) {
+      return this._idItemSeed + '-' + index;
     }
 
     /**


### PR DESCRIPTION
 #23 First of all, I used the branch with demo integration as a base to create this PR. Do not merge to master until the other one is merged.

The changes I have introduced now make the component more accessible: I have tested with Voice Over (macOS) and NVDM (Windows).

To test with voice over, enable it with Command + F5 and you will see that the voiceover announce the purpose of the element and while you highlight an option, that option is being announced as well. This is the same for NVDA, of course.

I have followed, as much as I can, ARIA Authoring Specs: https://www.w3.org/TR/wai-aria-practices-1.1/

It is not 100% okay with the specs, but at least is now usable for users with Screen Readers.
