### PR TITLE
Fix for textProperty and valueProperty when remoteSource is true

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -150,8 +150,8 @@
       <script>
         var paperToast = document.querySelector('paper-toast');
 
-        document.addEventListener('autocomplete-selected', onSelect);
-        document.addEventListener('autocomplete-change', onChange);
+        document.querySelector('#input-remote').addEventListener('autocomplete-selected', onSelect);
+        document.querySelector('#input-remote').addEventListener('autocomplete-change', onChange);
 
         function onSelect(event) {
           var selected = event.detail.text;
@@ -172,6 +172,55 @@
                 return {text: obj.login, value: obj.login};
               });
               input.suggestions(arr);
+            }
+          };
+          req.send();
+        }
+      </script>
+    </template>
+  </demo-snippet>
+
+  <h3>Remote Data-Source Binding with Custom Text & Value properties</h3>
+  <p>
+    Remote bind to the github user api. Remote data binding delegates the responsibility of filtering the data source to
+    the calling app. Set a listener for the <span class="bold">autocomplete.change</span> event and pass the suggestions
+    back to the component. The change event is fired based on the <span class="bold">min-length</span> attribute
+    setting.
+  </p>
+
+  <demo-snippet>
+    <template is="dom-bind">
+
+      <paper-autocomplete label="Select User"
+                          id="input-remote-custom-properties"
+                          text-property="login"
+                          value-property="id"
+                          min-length="2"
+                          remote-source>
+      </paper-autocomplete>
+
+      <script>
+        var paperToast = document.querySelector('paper-toast');
+
+        document.querySelector('#input-remote-custom-properties').addEventListener('autocomplete-selected', onCustomSelect);
+        document.querySelector('#input-remote-custom-properties').addEventListener('autocomplete-change', onCustomChange);
+
+        function onCustomSelect(event) {
+          var selected = event.detail.text;
+          paperToast.text = 'Selected: ' + selected + ' with a value ' + event.detail.value;
+          paperToast.show();
+        }
+
+        function onCustomChange(event) {
+          var input = document.querySelector('#input-remote-custom-properties');
+          var search = event.detail.option.text;
+          var url = 'https://api.github.com/search/users?q=' + search + '+in:login';
+          var req = new XMLHttpRequest();
+          req.open('GET', encodeURI(url));
+          req.onload = function () {
+            if (req.status === 200) {
+              var data = JSON.parse(req.response);
+              input.suggestions(data.items);
             }
           };
           req.send();

--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -94,7 +94,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <paper-material elevation="1" id="suggestionsWrapper">
       <template is="dom-repeat" items="{{_suggestions}}">
         <paper-item on-click="_onSelect">
-          <div>{{item.text}}</div>
+          <div>{{getItemText(item)}}</div>
           <paper-ripple></paper-ripple>
         </paper-item>
       </template>
@@ -309,6 +309,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._fireEvent(option,'reset');
     },
 
+	/**
+	 * Get the text property from the suggestion
+	 * @param {Object} suggestion The suggestion item
+	 * @return {String}
+	 */
+	getItemText: function(suggestion) {
+		return suggestion[this.textProperty];
+	},
+
     /**
      * Hide the suggestions wrapper
      */
@@ -390,8 +399,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _selection : function(index) {
       var selectedOption = this._suggestions[index];
       var self = this;
-      this.text = selectedOption.text;
-      this.value = selectedOption.value;
+      this.text = selectedOption[this.textProperty];
+      this.value = selectedOption[this.valueProperty];
       this._value=this.value;
       this._text=this.text;
       this.$.clear.style.display = 'none';
@@ -476,7 +485,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _fireEvent: function (option, evt) {
       var id=this._getId();
       var event='autocomplete' + this.eventNamespace + evt;
-      this.fire(event,{id:id,value:option.value,text:option.text,target:this,option:option});
+      this.fire(event,{id:id,value:option[this.valueProperty] || option.value,text:option[this.textProperty] || option.text,target:this,option:option
+	  });
     },
 
     _onKeypress:function(event){


### PR DESCRIPTION
If textProperty and/or valueProperty are defined on the component and remoteSource was true, these properties were not being used. This pull request fixes this issue.