### PR TITLE
Adding the posibility to provide custom template and custom search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This component follows *Semantic Versioning* (aka SemVer), visit (http://semver.org/) to learn more about it.
 
-## Release 2.0.0 (2016-11-XX)
+## Release 2.0.0 (2016-11-21)
 
 ### New Features
 - It is now possible to specify custom templates for suggestions.
@@ -14,4 +14,4 @@ This component follows *Semantic Versioning* (aka SemVer), visit (http://semver.
   it from your apps. However, if you have it, nothing will break, it will just be ignored.
   
 ### Bug Fixes
-- `setOption()` method was not taking into account `textProperty` and `valueProperty`.
+- `setOption()` method was not taking into account `textProperty` and `valueProperty` options.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+This component follows *Semantic Versioning* (aka SemVer), visit (http://semver.org/) to learn more about it.
+
+## Release 1.6.0 (2016-11-XX)
+
+### New Features
+- It is now possible to specify custom templates for suggestions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This component follows *Semantic Versioning* (aka SemVer), visit (http://semver.
 
 ### New Features
 - It is now possible to specify custom templates for suggestions.
-- You can now specify you own `queryFn` to filter suggestions according to your needs.
+- You can now specify your own `queryFn` to filter suggestions according to your needs.
 - Added `CHANGELOG.md`
 
 ### Breaking Change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ This component follows *Semantic Versioning* (aka SemVer), visit (http://semver.
 ### New Features
 - It is now possible to specify custom templates for suggestions.
 - You can now specify you own `queryFn` to filter suggestions according to your needs.
+- Added `CHANGELOG.md`
 
 ### Breaking Change
 - Property `useShadowDom` has been removed because now the component works in both modes without it. You can just remove
   it from your apps. However, if you have it, nothing will break, it will just be ignored.
+  
+### Bug Fixes
+- `setOption()` method was not taking into account `textProperty` and `valueProperty`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 This component follows *Semantic Versioning* (aka SemVer), visit (http://semver.org/) to learn more about it.
 
-## Release 1.6.0 (2016-11-XX)
+## Release 2.0.0 (2016-11-XX)
 
 ### New Features
 - It is now possible to specify custom templates for suggestions.
+- You can now specify you own `queryFn` to filter suggestions according to your needs.
+
+### Breaking Change
+- Property `useShadowDom` has been removed because now the component works in both modes without it. You can just remove
+  it from your apps. However, if you have it, nothing will break, it will just be ignored.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "paper-autocomplete",
-  "version": "1.5.1",
+  "version": "2.0.0",
   "authors": [
     "S. Francis",
     "Rodolfo Oviedo <rodo1111@gmail.com>",
@@ -16,6 +16,10 @@
   "main": "paper-autocomplete.html",
   "license": "MIT",
   "homepage": "https://github.com/ellipticaljs/paper-autocomplete/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ellipticaljs/paper-autocomplete.git"
+  },
   "ignore": [
     "/.*",
     "/test/"

--- a/demo/address-autocomplete.html
+++ b/demo/address-autocomplete.html
@@ -16,7 +16,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <dom-module id="address-autocomplete">
   <style>
+    :host {
+      display: block;
 
+      --paper-item: {
+        padding: 8px 16px;
+      }
+    }
+
+    .company-name {
+      color:#333;
+    }
+
+    .account-number {
+      margin-top: 4px;
+      color:#999;
+    }
   </style>
   <template>
     <paper-autocomplete
@@ -30,8 +45,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <div on-tap="_onSelect">
           <paper-item id$="[[_getSuggestionId(index)]]" role="option" aria-selected="false">
             <div>
-              <div>[[item.companyName]]</div>
-              <div>[[item.accountNumber]]</div>
+              <div class="company-name">[[item.companyName]]</div>
+              <div class="account-number">[[item.accountNumber]]</div>
             </div>
             <paper-ripple></paper-ripple>
           </paper-item>
@@ -121,10 +136,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     _queryFn: function (datasource, query) {
       return datasource.filter(function (item) {
-          return (
-            item.companyName.toLowerCase().indexOf(query) > 1 || item.accountNumber.toLowerCase().indexOf(query) > 1
-          );
-        });
+        return (
+          item.companyName.toLowerCase().indexOf(query) > 1 || item.accountNumber.toLowerCase().indexOf(query) > 1
+        );
+      });
     }
   });
 </script>

--- a/demo/address-autocomplete.html
+++ b/demo/address-autocomplete.html
@@ -47,7 +47,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       source="[[accounts]]"
       text-property="accountNumber"
       value-property="id">
-      <template>
+      <template autocomplete-custom-template>
         <div on-tap="_onSelect">
           <paper-item id$="[[_getSuggestionId(index)]]" role="option" aria-selected="false">
             <div>

--- a/demo/address-autocomplete.html
+++ b/demo/address-autocomplete.html
@@ -121,7 +121,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     ready: function () {
-      var autocomplete = this.querySelector('paper-autocomplete');
+      var autocomplete = this.$$('paper-autocomplete');
       autocomplete.addEventListener('autocomplete-selected', this.onSelect);
 
       autocomplete.queryFn = this._queryFn;

--- a/demo/address-autocomplete.html
+++ b/demo/address-autocomplete.html
@@ -1,0 +1,130 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../paper-autocomplete.html">
+
+<!--
+  Example of usage of autocomplete with custom template
+-->
+
+<dom-module id="address-autocomplete">
+  <style>
+
+  </style>
+  <template>
+    <paper-autocomplete
+      label="Select Account"
+      id="input-local"
+      no-label-float="true"
+      source="[[accounts]]"
+      text-property="accountNumber"
+      value-property="id">
+      <template>
+        <div on-tap="_onSelect">
+          <paper-item id$="[[_getSuggestionId(index)]]" role="option" aria-selected="false">
+            <div>
+              <div>[[item.companyName]]</div>
+              <div>[[item.accountNumber]]</div>
+            </div>
+            <paper-ripple></paper-ripple>
+          </paper-item>
+        </div>
+      </template>
+    </paper-autocomplete>
+  </template>
+</dom-module>
+
+<script>
+  var accounts = [
+      {"companyName":"Medhurst Group","accountNumber":"GE42 HE04 5984 5023 3261 28","id":"61aa0bb3-0ea9-45b2-a399-eb068fc535b6"},
+      {"companyName":"Zemlak and Sons","accountNumber":"GT30 MRUJ NOYD VD52 WFGW XTNB QCWF","id":"7fa52f45-c2f6-491d-ab60-810e61720253"},
+      {"companyName":"Emard, Heathcote and Rodriguez","accountNumber":"GE22 OS36 9571 4570 4313 69","id":"647636bb-ca39-491b-934a-971ae7ee799a"},
+      {"companyName":"Harvey, Koepp and Skiles","accountNumber":"MC38 8733 6302 15CO N5H3 WUOH 766","id":"ac34ddd2-a2a0-48e6-9459-852cb06397c0"},
+      {"companyName":"Moen-Padberg","accountNumber":"FR78 5375 0679 74B8 RNUM 9QQE S82","id":"4733f9d7-d723-4e6c-9920-6bbea01b4b10"},
+      {"companyName":"Bahringer, Purdy and Lueilwitz","accountNumber":"GB40 AVZH 6271 6084 0379 25","id":"209af640-61ce-4c38-98dd-22fb361352da"},
+      {"companyName":"Bartell, Roberts and Strosin","accountNumber":"IT93 X642 1322 956M J41J TUD1 AO3","id":"e916cfce-d0bc-4ba7-8d6e-882626a14b41"},
+      {"companyName":"Price Inc","accountNumber":"FR70 6740 9427 286D UHIY ANFN Z41","id":"42bff9fd-3571-4504-9046-ab8e32ab3618"},
+      {"companyName":"Kshlerin-Metz","accountNumber":"FR67 1447 0340 40OW DU8Q PVSZ Z74","id":"4f316079-e72d-40a0-b451-5def7ffa21b0"},
+      {"companyName":"King and Sons","accountNumber":"HR54 8640 1360 1935 8832 8","id":"7b121dbc-6845-49e9-8a79-5d0681b9d1e6"},
+      {"companyName":"Runolfsson-Runte","accountNumber":"CZ44 8154 0873 8066 3293 6557","id":"e2527ee0-9af2-4ac5-a36c-efd68bee40fe"},
+      {"companyName":"Morissette Inc","accountNumber":"FR31 4547 6013 95Z5 JYZF SI6W C58","id":"494c33f6-c0a5-42c7-a627-8bd585c953b5"},
+      {"companyName":"Klocko, Halvorson and Weber","accountNumber":"PT04 7967 3545 3660 3284 1138 4","id":"f48235d4-7321-4d3d-b2dd-fc7e52c4046f"},
+      {"companyName":"Renner Group","accountNumber":"FR38 9372 0492 44AI TOFP CQ7V R50","id":"3cca3a18-0560-416e-9ad6-2bd06bcc466f"},
+      {"companyName":"Reinger, Bode and Hahn","accountNumber":"FR55 8288 9216 96GB O2AO ERA6 U14","id":"e1c45dd1-1abc-4c98-9c95-e08af90b2704"},
+      {"companyName":"Marks, Zemlak and Denesik","accountNumber":"PL57 8564 3770 0917 6346 4898 8442","id":"9c182dd3-0c17-41d5-b6c8-c77a965ce408"},
+      {"companyName":"Johnston, Parker and Hickle","accountNumber":"SE17 8588 0484 5036 0373 6773","id":"edeb4333-824e-4b38-94f3-3ab88b2404c6"},
+      {"companyName":"Hackett, Pacocha and Tremblay","accountNumber":"VG57 IIXV 7638 1740 5291 5590","id":"e8766e34-7c2f-490a-b2e7-308e6615c937"},
+      {"companyName":"Hammes, Kirlin and Terry","accountNumber":"BA67 7688 6129 2639 2914","id":"a8e92c3a-5951-4625-a848-0a422c49c2ad"},
+      {"companyName":"Jacobson Inc","accountNumber":"AT44 2312 1717 5784 7855","id":"95193add-a046-4f1e-bdc0-9e56ec7ea5ac"},
+      {"companyName":"Bernhard, Crona and Breitenberg","accountNumber":"HR09 3821 2998 1029 7028 9","id":"be5d9c16-ab58-4f8d-8a07-c153c92020de"},
+      {"companyName":"Durgan, Frami and Kuhn","accountNumber":"RO32 HWNP P0P8 EA3I ERDS 23YT","id":"fc2a86b4-e646-49e1-97a6-a7ee22d5c893"},
+      {"companyName":"Stoltenberg-Osinski","accountNumber":"FR51 3687 4702 88EU XB9Q 4MXW I42","id":"fb4f5d48-caf3-4675-a439-9debbef5a061"},
+      {"companyName":"Ankunding, Smith and Leffler","accountNumber":"RS45 1641 5158 1113 2855 81","id":"07fb660c-951c-487a-be7c-38580670bf7b"},
+      {"companyName":"Harvey and Sons","accountNumber":"MU37 TTRE 3849 7030 1339 4306 951U DH","id":"0d921826-b907-41f6-80e6-60d6b027a14c"},
+      {"companyName":"Hilll-Johnston","accountNumber":"FR07 9006 8615 389Q DZAJ TGXA L62","id":"70d5d1ee-2cb7-465b-b5b8-f98227f8d1b9"},
+      {"companyName":"Adams, Shields and Feeney","accountNumber":"MC32 3779 9532 56JJ B7WN 4APV 419","id":"fb77a560-f003-49a2-9ae3-d3d4392a587b"},
+      {"companyName":"Macejkovic, Bergstrom and Kunze","accountNumber":"HR38 2529 9889 8253 8719 9","id":"8c120cca-f96e-4f04-bf2b-6ce504683f3c"},
+      {"companyName":"Runte-Spinka","accountNumber":"GR84 5639 771W QOXU FLDG YCUW 1O1","id":"b7c88870-505d-40dc-a3d4-c7e47161eead"},
+      {"companyName":"McCullough Group","accountNumber":"IS77 9923 0143 2412 1758 6750 94","id":"b50b3f2a-c0b2-41ba-b0a0-49991d556623"},
+      {"companyName":"Ruecker, Schultz and Moore","accountNumber":"FR27 9358 8283 81XE MQJ9 UD6Z B55","id":"a2fd8cad-8bc6-4bd0-9fda-7d18e9dae650"},
+      {"companyName":"Wiegand, Beahan and Kertzmann","accountNumber":"MR80 9172 8914 6084 0178 1466 996","id":"81177646-fe13-47ed-bd72-fdca582e53b3"},
+      {"companyName":"Stark, Deckow and Rempel","accountNumber":"GI61 TBYE E9KG TN8R W0QJ PQQ","id":"bede1e6d-8452-4d1e-96a7-f2a95932e7ac"},
+      {"companyName":"Stehr, Kozey and Johns","accountNumber":"AT91 1069 8191 5359 8661","id":"e7aab6d4-e3bd-4d11-8f5a-d342a894d29a"},
+      {"companyName":"Mills Inc","accountNumber":"FR23 5776 8889 37BX BS3A 1FNW T37","id":"d1410d2c-cd74-4fc1-9cc3-278d8419a2f2"},
+      {"companyName":"Crist, Skiles and Nienow","accountNumber":"BE87 0818 7391 1265","id":"2e6c0ebb-3a59-4d42-b6a5-bf846b81f3f5"},
+      {"companyName":"Blanda-Frami","accountNumber":"MR81 2219 7534 8435 3890 2163 556","id":"3142bdaf-be9c-4740-853b-42e9f3db768b"},
+      {"companyName":"Kihn-Reichel","accountNumber":"LI41 6772 90RL 2SR7 8ZY8 F","id":"e1f6081a-feb9-428f-8b50-c1099697b333"},
+      {"companyName":"Ondricka-Bayer","accountNumber":"FR51 3969 8994 40AJ P6DT UJAZ O92","id":"cb411aea-5591-4a65-8d76-682d38e0ee71"},
+      {"companyName":"Mayer-Herman","accountNumber":"FR92 0908 0633 17E5 MFWL VKU7 Z52","id":"95cee244-fdf0-42f2-86cf-b47428619007"},
+      {"companyName":"Haag, Olson and Jerde","accountNumber":"KW87 ANNS HQKN ILKA PW4G 0XME CU5T 7G","id":"56bedf72-9133-4a1e-b1b9-a4532c83cbf9"},
+      {"companyName":"Doyle LLC","accountNumber":"FR72 8979 8596 62WU G2GF JRJR C29","id":"84173887-ee15-4c6f-89ee-6ec7c9398089"},
+      {"companyName":"Macejkovic LLC","accountNumber":"GT69 YLRQ ARR5 F03Y NWRS OHHP UOLU","id":"11312e36-a468-460a-9b9d-ee4e4dc978b8"},
+      {"companyName":"Maggio, Torphy and Dooley","accountNumber":"DK39 2549 0183 9099 11","id":"ee42a061-4bb7-47f0-a044-a573478bef71"},
+      {"companyName":"Kling-Beatty","accountNumber":"AE80 4863 0876 8895 2715 261","id":"f12b209d-156e-47ee-9d3b-536fb919c9af"},
+      {"companyName":"Harris and Sons","accountNumber":"FR23 0641 2303 15U8 EWL2 LRDI X66","id":"c25d1d4b-3599-455f-b36a-0debd4524ff5"},
+      {"companyName":"Berge, Gibson and Hermann","accountNumber":"FR65 8329 8954 90MC 9FJE QLAF T88","id":"bc35dbaf-681f-42b0-81bc-d845ea064e10"},
+      {"companyName":"Hirthe, Borer and Parker","accountNumber":"NO46 5775 1320 183","id":"7180892d-2216-49bf-b504-2a7703309270"},
+      {"companyName":"Bode Group","accountNumber":"EE61 7633 0406 0044 2526","id":"376d0312-2e0c-415c-87d6-418e9bec9ca1"},
+      {"companyName":"Considine, Strosin and Heller","accountNumber":"PK85 MNMA NAZX PXHW O4JV P3JH","id":"d39f18b5-1a3f-4da0-8e56-03c5e092d6d1"}
+    ];
+
+  Polymer({
+    is: "address-autocomplete",
+
+    properties: {
+      accounts: {
+        type: Array,
+        value: accounts
+      }
+    },
+
+    ready: function () {
+      var autocomplete = this.querySelector('paper-autocomplete');
+      autocomplete.addEventListener('autocomplete-selected', this.onSelect);
+
+      autocomplete.queryFn = this._queryFn;
+    },
+
+    onSelect: function () {
+      var paperToast = document.querySelector('paper-toast');
+      var selected = event.detail.text;
+      paperToast.text = 'Selected: ' + selected;
+      paperToast.show();
+    },
+
+    _queryFn: function (datasource, query) {
+      return datasource.filter(function (item) {
+          return (
+            item.companyName.toLowerCase().indexOf(query) > 1 || item.accountNumber.toLowerCase().indexOf(query) > 1
+          );
+        });
+    }
+  });
+</script>

--- a/demo/address-autocomplete.html
+++ b/demo/address-autocomplete.html
@@ -48,16 +48,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       text-property="accountNumber"
       value-property="id">
       <template autocomplete-custom-template>
-        <div on-tap="_onSelect">
-          <paper-item id$="[[_getSuggestionId(index)]]" role="option" aria-selected="false">
-            <div>
-              <div class="company-name">[[item.companyName]]</div>
-              <div class="account-number">[[item.accountNumber]]</div>
-              <div class="email">[[item.email]]</div>
-            </div>
-            <paper-ripple></paper-ripple>
-          </paper-item>
-        </div>
+        <paper-item on-tap="_onSelect" id$="[[_getSuggestionId(index)]]" role="option" aria-selected="false">
+          <div>
+            <div class="company-name">[[item.companyName]]</div>
+            <div class="account-number">[[item.accountNumber]]</div>
+            <div class="email">[[item.email]]</div>
+          </div>
+          <paper-ripple></paper-ripple>
+        </paper-item>
       </template>
     </paper-autocomplete>
   </template>
@@ -147,7 +145,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _queryFn: function (datasource, query) {
       return datasource.filter(function (item) {
         return (
-          item.companyName.toLowerCase().indexOf(query) > 1 || item.accountNumber.toLowerCase().indexOf(query) > 1
+          item.companyName.toLowerCase().indexOf(query) != -1 || item.accountNumber.toLowerCase().indexOf(query) != -1
         );
       });
     }

--- a/demo/address-autocomplete.html
+++ b/demo/address-autocomplete.html
@@ -11,7 +11,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../paper-autocomplete.html">
 
 <!--
-  Example of usage of autocomplete with custom template
+  This example shows how to implement your own autocomplete with custom template and search function.
 -->
 
 <dom-module id="address-autocomplete">
@@ -28,12 +28,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       color:#333;
     }
 
-    .account-number {
+    .account-number, .email {
       margin-top: 4px;
       color:#999;
     }
+
+    .email {
+      font-size: small;
+    }
   </style>
   <template>
+    <!-- When using custom template and or custom query function, it is important to also set the `textProperty`
+     and `valueProperty properties`. -->
     <paper-autocomplete
       label="Select Account"
       id="input-local"
@@ -47,6 +53,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             <div>
               <div class="company-name">[[item.companyName]]</div>
               <div class="account-number">[[item.accountNumber]]</div>
+              <div class="email">[[item.email]]</div>
             </div>
             <paper-ripple></paper-ripple>
           </paper-item>
@@ -58,57 +65,57 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
   var accounts = [
-      {"companyName":"Medhurst Group","accountNumber":"GE42 HE04 5984 5023 3261 28","id":"61aa0bb3-0ea9-45b2-a399-eb068fc535b6"},
-      {"companyName":"Zemlak and Sons","accountNumber":"GT30 MRUJ NOYD VD52 WFGW XTNB QCWF","id":"7fa52f45-c2f6-491d-ab60-810e61720253"},
-      {"companyName":"Emard, Heathcote and Rodriguez","accountNumber":"GE22 OS36 9571 4570 4313 69","id":"647636bb-ca39-491b-934a-971ae7ee799a"},
-      {"companyName":"Harvey, Koepp and Skiles","accountNumber":"MC38 8733 6302 15CO N5H3 WUOH 766","id":"ac34ddd2-a2a0-48e6-9459-852cb06397c0"},
-      {"companyName":"Moen-Padberg","accountNumber":"FR78 5375 0679 74B8 RNUM 9QQE S82","id":"4733f9d7-d723-4e6c-9920-6bbea01b4b10"},
-      {"companyName":"Bahringer, Purdy and Lueilwitz","accountNumber":"GB40 AVZH 6271 6084 0379 25","id":"209af640-61ce-4c38-98dd-22fb361352da"},
-      {"companyName":"Bartell, Roberts and Strosin","accountNumber":"IT93 X642 1322 956M J41J TUD1 AO3","id":"e916cfce-d0bc-4ba7-8d6e-882626a14b41"},
-      {"companyName":"Price Inc","accountNumber":"FR70 6740 9427 286D UHIY ANFN Z41","id":"42bff9fd-3571-4504-9046-ab8e32ab3618"},
-      {"companyName":"Kshlerin-Metz","accountNumber":"FR67 1447 0340 40OW DU8Q PVSZ Z74","id":"4f316079-e72d-40a0-b451-5def7ffa21b0"},
-      {"companyName":"King and Sons","accountNumber":"HR54 8640 1360 1935 8832 8","id":"7b121dbc-6845-49e9-8a79-5d0681b9d1e6"},
-      {"companyName":"Runolfsson-Runte","accountNumber":"CZ44 8154 0873 8066 3293 6557","id":"e2527ee0-9af2-4ac5-a36c-efd68bee40fe"},
-      {"companyName":"Morissette Inc","accountNumber":"FR31 4547 6013 95Z5 JYZF SI6W C58","id":"494c33f6-c0a5-42c7-a627-8bd585c953b5"},
-      {"companyName":"Klocko, Halvorson and Weber","accountNumber":"PT04 7967 3545 3660 3284 1138 4","id":"f48235d4-7321-4d3d-b2dd-fc7e52c4046f"},
-      {"companyName":"Renner Group","accountNumber":"FR38 9372 0492 44AI TOFP CQ7V R50","id":"3cca3a18-0560-416e-9ad6-2bd06bcc466f"},
-      {"companyName":"Reinger, Bode and Hahn","accountNumber":"FR55 8288 9216 96GB O2AO ERA6 U14","id":"e1c45dd1-1abc-4c98-9c95-e08af90b2704"},
-      {"companyName":"Marks, Zemlak and Denesik","accountNumber":"PL57 8564 3770 0917 6346 4898 8442","id":"9c182dd3-0c17-41d5-b6c8-c77a965ce408"},
-      {"companyName":"Johnston, Parker and Hickle","accountNumber":"SE17 8588 0484 5036 0373 6773","id":"edeb4333-824e-4b38-94f3-3ab88b2404c6"},
-      {"companyName":"Hackett, Pacocha and Tremblay","accountNumber":"VG57 IIXV 7638 1740 5291 5590","id":"e8766e34-7c2f-490a-b2e7-308e6615c937"},
-      {"companyName":"Hammes, Kirlin and Terry","accountNumber":"BA67 7688 6129 2639 2914","id":"a8e92c3a-5951-4625-a848-0a422c49c2ad"},
-      {"companyName":"Jacobson Inc","accountNumber":"AT44 2312 1717 5784 7855","id":"95193add-a046-4f1e-bdc0-9e56ec7ea5ac"},
-      {"companyName":"Bernhard, Crona and Breitenberg","accountNumber":"HR09 3821 2998 1029 7028 9","id":"be5d9c16-ab58-4f8d-8a07-c153c92020de"},
-      {"companyName":"Durgan, Frami and Kuhn","accountNumber":"RO32 HWNP P0P8 EA3I ERDS 23YT","id":"fc2a86b4-e646-49e1-97a6-a7ee22d5c893"},
-      {"companyName":"Stoltenberg-Osinski","accountNumber":"FR51 3687 4702 88EU XB9Q 4MXW I42","id":"fb4f5d48-caf3-4675-a439-9debbef5a061"},
-      {"companyName":"Ankunding, Smith and Leffler","accountNumber":"RS45 1641 5158 1113 2855 81","id":"07fb660c-951c-487a-be7c-38580670bf7b"},
-      {"companyName":"Harvey and Sons","accountNumber":"MU37 TTRE 3849 7030 1339 4306 951U DH","id":"0d921826-b907-41f6-80e6-60d6b027a14c"},
-      {"companyName":"Hilll-Johnston","accountNumber":"FR07 9006 8615 389Q DZAJ TGXA L62","id":"70d5d1ee-2cb7-465b-b5b8-f98227f8d1b9"},
-      {"companyName":"Adams, Shields and Feeney","accountNumber":"MC32 3779 9532 56JJ B7WN 4APV 419","id":"fb77a560-f003-49a2-9ae3-d3d4392a587b"},
-      {"companyName":"Macejkovic, Bergstrom and Kunze","accountNumber":"HR38 2529 9889 8253 8719 9","id":"8c120cca-f96e-4f04-bf2b-6ce504683f3c"},
-      {"companyName":"Runte-Spinka","accountNumber":"GR84 5639 771W QOXU FLDG YCUW 1O1","id":"b7c88870-505d-40dc-a3d4-c7e47161eead"},
-      {"companyName":"McCullough Group","accountNumber":"IS77 9923 0143 2412 1758 6750 94","id":"b50b3f2a-c0b2-41ba-b0a0-49991d556623"},
-      {"companyName":"Ruecker, Schultz and Moore","accountNumber":"FR27 9358 8283 81XE MQJ9 UD6Z B55","id":"a2fd8cad-8bc6-4bd0-9fda-7d18e9dae650"},
-      {"companyName":"Wiegand, Beahan and Kertzmann","accountNumber":"MR80 9172 8914 6084 0178 1466 996","id":"81177646-fe13-47ed-bd72-fdca582e53b3"},
-      {"companyName":"Stark, Deckow and Rempel","accountNumber":"GI61 TBYE E9KG TN8R W0QJ PQQ","id":"bede1e6d-8452-4d1e-96a7-f2a95932e7ac"},
-      {"companyName":"Stehr, Kozey and Johns","accountNumber":"AT91 1069 8191 5359 8661","id":"e7aab6d4-e3bd-4d11-8f5a-d342a894d29a"},
-      {"companyName":"Mills Inc","accountNumber":"FR23 5776 8889 37BX BS3A 1FNW T37","id":"d1410d2c-cd74-4fc1-9cc3-278d8419a2f2"},
-      {"companyName":"Crist, Skiles and Nienow","accountNumber":"BE87 0818 7391 1265","id":"2e6c0ebb-3a59-4d42-b6a5-bf846b81f3f5"},
-      {"companyName":"Blanda-Frami","accountNumber":"MR81 2219 7534 8435 3890 2163 556","id":"3142bdaf-be9c-4740-853b-42e9f3db768b"},
-      {"companyName":"Kihn-Reichel","accountNumber":"LI41 6772 90RL 2SR7 8ZY8 F","id":"e1f6081a-feb9-428f-8b50-c1099697b333"},
-      {"companyName":"Ondricka-Bayer","accountNumber":"FR51 3969 8994 40AJ P6DT UJAZ O92","id":"cb411aea-5591-4a65-8d76-682d38e0ee71"},
-      {"companyName":"Mayer-Herman","accountNumber":"FR92 0908 0633 17E5 MFWL VKU7 Z52","id":"95cee244-fdf0-42f2-86cf-b47428619007"},
-      {"companyName":"Haag, Olson and Jerde","accountNumber":"KW87 ANNS HQKN ILKA PW4G 0XME CU5T 7G","id":"56bedf72-9133-4a1e-b1b9-a4532c83cbf9"},
-      {"companyName":"Doyle LLC","accountNumber":"FR72 8979 8596 62WU G2GF JRJR C29","id":"84173887-ee15-4c6f-89ee-6ec7c9398089"},
-      {"companyName":"Macejkovic LLC","accountNumber":"GT69 YLRQ ARR5 F03Y NWRS OHHP UOLU","id":"11312e36-a468-460a-9b9d-ee4e4dc978b8"},
-      {"companyName":"Maggio, Torphy and Dooley","accountNumber":"DK39 2549 0183 9099 11","id":"ee42a061-4bb7-47f0-a044-a573478bef71"},
-      {"companyName":"Kling-Beatty","accountNumber":"AE80 4863 0876 8895 2715 261","id":"f12b209d-156e-47ee-9d3b-536fb919c9af"},
-      {"companyName":"Harris and Sons","accountNumber":"FR23 0641 2303 15U8 EWL2 LRDI X66","id":"c25d1d4b-3599-455f-b36a-0debd4524ff5"},
-      {"companyName":"Berge, Gibson and Hermann","accountNumber":"FR65 8329 8954 90MC 9FJE QLAF T88","id":"bc35dbaf-681f-42b0-81bc-d845ea064e10"},
-      {"companyName":"Hirthe, Borer and Parker","accountNumber":"NO46 5775 1320 183","id":"7180892d-2216-49bf-b504-2a7703309270"},
-      {"companyName":"Bode Group","accountNumber":"EE61 7633 0406 0044 2526","id":"376d0312-2e0c-415c-87d6-418e9bec9ca1"},
-      {"companyName":"Considine, Strosin and Heller","accountNumber":"PK85 MNMA NAZX PXHW O4JV P3JH","id":"d39f18b5-1a3f-4da0-8e56-03c5e092d6d1"}
-    ];
+    {"companyName":"Goyette-Lebsack","accountNumber":"CZ91 5363 3967 6009 8080 9459","id":"cb515c77-6924-476d-8c52-9744cb84dc09","email":"kfranklin0@addthis.com"},
+    {"companyName":"Hickle, Lesch and Bernier","accountNumber":"AL38 5705 1570 WVGB 9W0Y KIVE JDPN","id":"6404e851-85cc-4d0d-9b19-9c8932e03522","email":"ccruz1@goo.gl"},
+    {"companyName":"Lemke, Marks and Ebert","accountNumber":"NO29 9240 0664 978","id":"212eb8d7-e340-43ab-a4f5-b39993cdc64a","email":"jmason2@weather.com"},
+    {"companyName":"VonRueden LLC","accountNumber":"PK78 QNNT EQWN KWPI 6VE3 ZMTF","id":"1d939765-699b-4300-bd22-c8609c3daf91","email":"tpatterson3@google.de"},
+    {"companyName":"Turner Group","accountNumber":"NL69 WPGC 0810 2315 77","id":"a65be6c9-f15b-47f1-84e6-4a36ba5d342c","email":"nreed4@mayoclinic.com"},
+    {"companyName":"Wunsch LLC","accountNumber":"TR26 4409 4WYW Y298 USQH XFPD 6I","id":"4ba8dac8-1c86-4842-8cea-3a4b35bbab08","email":"swells5@blog.com"},
+    {"companyName":"Shields LLC","accountNumber":"CR96 0129 6245 5124 3415 9","id":"326b1f1c-3da8-4ae5-aa64-53352ed06df1","email":"jgonzales6@barnesandnoble.com"},
+    {"companyName":"Stokes LLC","accountNumber":"SI55 7134 3290 9404 318","id":"d96e2665-1366-4b2e-bf70-4e31a4ea32a6","email":"wfox7@sogou.com"},
+    {"companyName":"D'Amore, Bartell and Kassulke","accountNumber":"KZ02 680T BASZ VX4M ZPGQ","id":"eb4a180f-48bf-460c-8900-3bb387a63ab0","email":"slittle8@networkadvertising.org"},
+    {"companyName":"Mertz-Murazik","accountNumber":"FR09 5126 6343 196F 7VWK VIDA G96","id":"51959b7c-aef4-4f4c-8723-64df15711e45","email":"jchavez9@livejournal.com"},
+    {"companyName":"Johnson, Brown and Yost","accountNumber":"MD45 SVBP ORA2 QT02 0TKC K2J8","id":"95c234b3-28a3-4c3d-a4f7-cc1a5484068f","email":"bhamiltona@ucsd.edu"},
+    {"companyName":"Parker Group","accountNumber":"NL38 VMVJ 8279 9808 79","id":"533df586-7db5-44dd-95a1-c072ad86498b","email":"gbennettb@ebay.co.uk"},
+    {"companyName":"Reichert-Dietrich","accountNumber":"GB53 UPQZ 2929 8469 2084 82","id":"ab246670-d7f6-4bfe-b6d6-c9502dd544a8","email":"mstephensc@printfriendly.com"},
+    {"companyName":"Koss Inc","accountNumber":"MT65 CSOW 0933 9HJF N68S XY1U DUTS TIW","id":"c8e13922-3ee0-4a00-9097-7729d5c0bca2","email":"cwoodsd@boston.com"},
+    {"companyName":"Robel-Schamberger","accountNumber":"GR42 9311 1604 CTQD RKNI 5WDY GZT","id":"46201b92-a84c-41d8-b021-ffc8e3eb7317","email":"ewoodse@google.com.br"},
+    {"companyName":"McCullough-Wuckert","accountNumber":"FR28 8910 2871 58WA A8BB FIP7 W69","id":"3e25e4e7-a924-4236-8a55-41c5facc04ce","email":"maustinf@ebay.co.uk"},
+    {"companyName":"Schoen Group","accountNumber":"AD83 5460 5839 DLOV HCVZ UVGN","id":"7194dc0e-6424-42fb-a4dd-07ac19e55a5a","email":"vvasquezg@moonfruit.com"},
+    {"companyName":"Robel Group","accountNumber":"CR55 2138 8499 1123 9528 3","id":"bdd33891-f35e-4677-84ae-e41c84aac906","email":"lpalmerh@toplist.cz"},
+    {"companyName":"Osinski Group","accountNumber":"BA40 3816 2941 7503 0366","id":"cad1e8fe-0843-43e1-a4de-498076539a2f","email":"bbrooksi@ed.gov"},
+    {"companyName":"Rogahn LLC","accountNumber":"DK24 2489 6562 1456 96","id":"89f3af17-14cb-4ab3-97cb-083560340e48","email":"mrichardsonj@examiner.com"},
+    {"companyName":"Schneider LLC","accountNumber":"AL50 0809 6195 TPKO WUKX LYBS WK9O","id":"714d9f4b-7d94-4dd5-a547-cc447b76572d","email":"rgrahamk@google.com.au"},
+    {"companyName":"Thiel-Wolff","accountNumber":"LU46 487L PJFS EUEM DWBB","id":"91d922ac-6e5d-4d2d-bf8d-470ecde631cc","email":"amoorel@google.pl"},
+    {"companyName":"Klocko-Morissette","accountNumber":"DE98 2950 1475 1384 8332 59","id":"2198ec78-6e49-4009-8476-85908f22af3b","email":"scollinsm@redcross.org"},
+    {"companyName":"Lang and Sons","accountNumber":"FO92 9851 3237 4481 79","id":"921a75be-d8c9-404d-9768-6a377a8f4ae0","email":"abanksn@cdc.gov"},
+    {"companyName":"Shanahan, Kuhn and Dach","accountNumber":"IS75 2784 1832 1107 2594 7887 06","id":"13f033c8-2efd-471b-8bf3-aff46fb55bbe","email":"jbello@taobao.com"},
+    {"companyName":"Hoeger Inc","accountNumber":"AE58 6081 9517 8466 8326 395","id":"ccafa40c-5b79-4699-8daf-4b775a048809","email":"eryanp@github.io"},
+    {"companyName":"Stamm-Berge","accountNumber":"LT97 9487 9945 5964 0855","id":"d0777bec-1a52-4943-9690-43574c445952","email":"mhenryq@independent.co.uk"},
+    {"companyName":"Jacobson LLC","accountNumber":"FR96 2204 9241 245A 1KLB W5GK V84","id":"7471b59d-a930-4f49-8180-56d0686acabf","email":"rsanchezr@hud.gov"},
+    {"companyName":"Cremin, Farrell and Schamberger","accountNumber":"CR75 1654 3259 1325 0162 1","id":"23b8ff26-079d-4e3a-b8e1-246e02ff12d1","email":"dblacks@nydailynews.com"},
+    {"companyName":"Ratke, Russel and Rippin","accountNumber":"FR31 6006 9483 81GD BJW6 KUX2 R57","id":"10ecf3e7-e6ee-4854-aa2e-a8d603406626","email":"mmillert@topsy.com"},
+    {"companyName":"Senger, Kling and Robel","accountNumber":"CY12 1871 5800 KJZC MQNK 3XSN LY2I","id":"91827148-79b5-452b-9682-14f494588720","email":"kweaveru@state.gov"},
+    {"companyName":"Little, Fay and Littel","accountNumber":"BH02 MAZS TUTX SPUA CQ0Q IA","id":"b1c95a8b-6637-4a02-a03d-2d877f89e801","email":"lmarshallv@w3.org"},
+    {"companyName":"Weimann LLC","accountNumber":"FR62 4140 1117 14BD KS93 Z4DY T72","id":"36ac519b-5b91-4510-a7f7-2fd86f1c84cf","email":"dwilliamsw@statcounter.com"},
+    {"companyName":"Rosenbaum-Reilly","accountNumber":"FR29 9781 0626 68YE ATXL AUZX A02","id":"349623e0-c70e-4f4a-81b0-fe97493c1004","email":"dromerox@deliciousdays.com"},
+    {"companyName":"Schulist, Cummerata and Stark","accountNumber":"MD35 JBJS 3B24 KMJZ EQBC P2L5","id":"442f0418-616c-468c-a675-82c48c6a85d2","email":"wmitchelly@indiatimes.com"},
+    {"companyName":"Labadie, Berge and Nitzsche","accountNumber":"TN58 9199 1295 1298 8485 6860","id":"24a10110-196c-4e5a-800d-e9c2840d8f11","email":"cwillisz@posterous.com"},
+    {"companyName":"Thiel, Lubowitz and Steuber","accountNumber":"PT93 7074 3585 3013 0626 2982 4","id":"757efd3c-c5b0-4354-a1c2-7b720438c40c","email":"cgarza10@paginegialle.it"},
+    {"companyName":"Denesik Group","accountNumber":"FR67 3927 8003 17A8 NGLX N9IN V34","id":"0fefdb3b-623c-4ab7-b18a-1aa1d13153a2","email":"ksanders11@engadget.com"},
+    {"companyName":"Quigley-Connelly","accountNumber":"DE16 7623 6589 6140 4180 73","id":"d6232f9e-8238-4fad-a9b3-d1f7b3b414cc","email":"randerson12@ca.gov"},
+    {"companyName":"Bode, Powlowski and Crist","accountNumber":"EE11 7981 1234 7093 7516","id":"eecdfb64-347d-47e0-9c8c-472f2e0633ae","email":"nholmes13@clickbank.net"},
+    {"companyName":"Zieme Group","accountNumber":"SI93 3362 4713 5070 208","id":"74f2a333-dc6b-49d8-9d42-621311e892b4","email":"hwilliamson14@dell.com"},
+    {"companyName":"Howell, Feil and Cole","accountNumber":"LT23 2439 3445 1074 1172","id":"387287f1-1ca0-4df1-bbab-a89e1fe5589b","email":"hvasquez15@disqus.com"},
+    {"companyName":"Parisian Inc","accountNumber":"GE37 SF47 9252 2109 5152 75","id":"f85935d8-9145-4490-b61f-3599f4250273","email":"khughes16@narod.ru"},
+    {"companyName":"Windler, Steuber and Weimann","accountNumber":"VG81 PAAZ 6939 1423 0151 2412","id":"aee2c3fb-f5ad-4c05-94a1-53e3cf56397f","email":"tandrews17@etsy.com"},
+    {"companyName":"Brakus Group","accountNumber":"AE02 4483 3368 7994 4390 087","id":"257e34a2-5fbe-4315-8140-2c385525db87","email":"khanson18@amazon.de"},
+    {"companyName":"Nader and Sons","accountNumber":"AT68 1544 6823 2068 9934","id":"d4330e6d-2a40-4419-82d5-76aa466b1514","email":"lwelch19@icq.com"},
+    {"companyName":"Kuhic, Brakus and Rau","accountNumber":"SE49 7126 3863 9030 4260 8125","id":"413bc218-3aa7-40af-ba37-fe25314b7620","email":"rmatthews1a@tamu.edu"},
+    {"companyName":"Langworth, Dooley and Nicolas","accountNumber":"LB83 8665 LZJF YZLS W4YD X0I1 REBU","id":"078a7a5a-ac6e-40e4-891e-3375de2cc931","email":"sbennett1b@wikispaces.com"},
+    {"companyName":"Kertzmann and Sons","accountNumber":"DE62 0488 3729 1890 2853 48","id":"07e79298-7530-4d03-911e-fc2e0148f57e","email":"jadams1c@telegraph.co.uk"},
+    {"companyName":"Toy-Mann","accountNumber":"ES77 2884 7115 0472 3496 6063","id":"79f91d5b-51d4-4516-a6b6-6257e12a200c","email":"awillis1d@bloomberg.com"}
+  ];
 
   Polymer({
     is: "address-autocomplete",
@@ -124,6 +131,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var autocomplete = this.$$('paper-autocomplete');
       autocomplete.addEventListener('autocomplete-selected', this.onSelect);
 
+      // Override default queryFn with our custom. This is a needed requirement to implement the custom template
       autocomplete.queryFn = this._queryFn;
     },
 
@@ -134,6 +142,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       paperToast.show();
     },
 
+    // This custom queryFn will filter results searching in both companyName and accountNumber, then it will return the
+    // whole data object so it can be accessed in the custom template
     _queryFn: function (datasource, query) {
       return datasource.filter(function (item) {
         return (

--- a/demo/autocomplete-example.html
+++ b/demo/autocomplete-example.html
@@ -90,6 +90,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     is: "autocomplete-example",
     ready: function () {
       Polymer.dom(this).querySelector('paper-autocomplete').source = states;
+
+      this.querySelector('paper-autocomplete').addEventListener('autocomplete-selected', this.onSelect);
+    },
+
+    onSelect: function () {
+      var paperToast = document.querySelector('paper-toast');
+      var selected = event.detail.text;
+      paperToast.text = 'Selected: ' + selected;
+      paperToast.show();
     }
   });
 </script>

--- a/demo/autocomplete-example.html
+++ b/demo/autocomplete-example.html
@@ -94,7 +94,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this.querySelector('paper-autocomplete').addEventListener('autocomplete-selected', this.onSelect);
     },
 
-    onSelect: function () {
+    onSelect: function (event) {
       var paperToast = document.querySelector('paper-toast');
       var selected = event.detail.text;
       paperToast.text = 'Selected: ' + selected;

--- a/demo/index.html
+++ b/demo/index.html
@@ -13,6 +13,7 @@
   <link rel="import" href="../../css-docs/css-docs.html">
   <link rel="import" href="../paper-autocomplete.html">
   <link rel="import" href="./autocomplete-example.html">
+  <link rel="import" href="./address-autocomplete.html">
 
   <link rel="stylesheet" href="demo.css">
 
@@ -155,6 +156,17 @@
           req.send();
         }
       </script>
+    </template>
+  </demo-snippet>
+
+  <h3>Custom template</h3>
+  <p>
+    This is an example using custom template... WIP
+  </p>
+
+  <demo-snippet>
+    <template is="dom-bind">
+      <address-autocomplete></address-autocomplete>
     </template>
   </demo-snippet>
 </div>

--- a/demo/index.html
+++ b/demo/index.html
@@ -188,12 +188,10 @@
                           min-length="2"
                           remote-source>
         <template autocomplete-custom-template>
-          <div on-tap="_onSelect">
-            <paper-item id$="[[_getSuggestionId(index)]]" role="option" aria-selected="false">
-              <img src$="[[item.avatar_url]]" height="50" width="50" style="margin: 8px 8px 8px 0; min-height: 50px;"/>[[item.login]]
-              <paper-ripple></paper-ripple>
-            </paper-item>
-          </div>
+          <paper-item on-tap="_onSelect" id$="[[_getSuggestionId(index)]]" role="option" aria-selected="false">
+            <img src$="[[item.avatar_url]]" height="50" width="50" style="margin: 8px 8px 8px 0; min-height: 50px;"/>[[item.login]]
+            <paper-ripple></paper-ripple>
+          </paper-item>
         </template>
       </paper-autocomplete>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -187,7 +187,7 @@
                           value-property="id"
                           min-length="2"
                           remote-source>
-        <template>
+        <template autocomplete-custom-template>
           <div on-tap="_onSelect">
             <paper-item id$="[[_getSuggestionId(index)]]" role="option" aria-selected="false">
               <img src$="[[item.avatar_url]]" height="50" width="50" style="margin: 8px 8px 8px 0; min-height: 50px;"/>[[item.login]]

--- a/demo/index.html
+++ b/demo/index.html
@@ -161,7 +161,8 @@
 
   <h3>Custom template</h3>
   <p>
-    This is an example using custom template... WIP
+    This is an example using custom template. Open the file `demo/address-autocomplete.html` in this repository to see
+    how it works internally. You can use that one as an example when you need to implement your own.
   </p>
 
   <demo-snippet>

--- a/demo/index.html
+++ b/demo/index.html
@@ -19,7 +19,7 @@
 
   <style is="custom-style" include="demo-pages-shared-styles">
     .vertical-section-container {
-      max-width: 600px;
+      max-width: 800px;
     }
   </style>
 </head>
@@ -167,6 +167,72 @@
   <demo-snippet>
     <template is="dom-bind">
       <address-autocomplete></address-autocomplete>
+    </template>
+  </demo-snippet>
+
+  <h3>Remote Data-Source Binding with custom template</h3>
+
+  <p>
+    This example is similar to previous remote one with the only difference that this time a custom template
+    is used.
+  </p>
+
+  <demo-snippet>
+    <template is="dom-bind">
+
+      <paper-autocomplete label="Select User"
+                          id="input-remote-custom-template"
+                          text-property="login"
+                          value-property="id"
+                          min-length="2"
+                          remote-source>
+        <template>
+          <div on-tap="_onSelect">
+            <paper-item id$="[[_getSuggestionId(index)]]" role="option" aria-selected="false">
+              <div>
+                <img src$="[[item.avatar_url]]" height="50" width="50" style="margin: 8px 8px 8px 0;"/>[[item.login]]
+              </div>
+              <paper-ripple></paper-ripple>
+            </paper-item>
+          </div>
+        </template>
+      </paper-autocomplete>
+
+      <script>
+        (function () {
+          var queryTimer = null;
+          var remoteInput = document.querySelector('#input-remote-custom-template');
+
+          remoteInput.addEventListener('autocomplete-selected', onCustomSelect);
+          remoteInput.addEventListener('autocomplete-change', onCustomChange);
+
+          function onCustomSelect(event) {
+            var paperToast = document.querySelector('paper-toast');
+            var selected = event.detail.text;
+            paperToast.text = 'Selected: ' + selected + ' with a value ' + event.detail.value;
+            paperToast.show();
+          }
+
+          function onCustomChange(event) {
+            clearTimeout(queryTimer);
+
+            queryTimer = setTimeout(function () {
+              var search = event.detail.option.text;
+              var url = 'https://api.github.com/search/users?q=' + search + '+in:login';
+              var req = new XMLHttpRequest();
+              req.open('GET', encodeURI(url));
+
+              req.onload = function () {
+                if (req.status === 200) {
+                  var data = JSON.parse(req.response);
+                  remoteInput.suggestions(data.items);
+                }
+              };
+              req.send();
+            }, 300);
+          }
+        }());
+      </script>
     </template>
   </demo-snippet>
 </div>

--- a/demo/index.html
+++ b/demo/index.html
@@ -189,9 +189,7 @@
         <template>
           <div on-tap="_onSelect">
             <paper-item id$="[[_getSuggestionId(index)]]" role="option" aria-selected="false">
-              <div>
-                <img src$="[[item.avatar_url]]" height="50" width="50" style="margin: 8px 8px 8px 0;"/>[[item.login]]
-              </div>
+              <img src$="[[item.avatar_url]]" height="50" width="50" style="margin: 8px 8px 8px 0; min-height: 50px;"/>[[item.login]]
               <paper-ripple></paper-ripple>
             </paper-item>
           </div>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "paper-autocomplete",
   "description": "Material Design autocomplete component.",
-  "version": "1.5.1",
+  "version": "2.0.0",
   "author": "S. Francis <sfrancis@misinteractive.com>",
   "contributors": [
     "Rodolfo Oviedo <rodo1111@gmail.com>",

--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -41,9 +41,44 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   ```
 
   ### Custom templates
-  TODO: document elements should have min height issue.
-  TODO: document wrapper
-  TODO: need to use textProperty and valueProperty for A11Y
+  A template for each suggestion can be provided, but for now, there are limitations in the way you can customize
+  the template. Please, read carefully all this section to know them.
+  In order to set your own template, you need to add a `<template>` tag with the following structure:
+
+  ```
+  <paper-autocomplete>
+    <template>
+      <div on-tap="_onSelect">
+        <paper-item id$="[[_getSuggestionId(index)]]" role="option" aria-selected="false">
+          YOUR CUSTOM TEMPLATE
+          <paper-ripple></paper-ripple>
+        </paper-item>
+      </div>
+    </template>
+  </paper-autocomplete>
+  ```
+
+  You need to always maintain this structure. Then you can customize the content of paper-item. These are the reasons
+  why you need to maintain it:
+
+  - The wrapper with `_onSelect` it is very important because it will notify the `autocomplete` component when user
+  selects one item.
+  - `id`, `role` and `aria-selected` need to be there for accessibility reasons.
+
+  It is important to note that methods `_onSelect` and `_getSuggestionId` do not need to be implemented. They are part
+  of the logic of `paper-autocomplete`.
+
+  When providing your own custom template, you might also need to provide your own custom search function. The reason
+  for that is that the default search function only exposes text and value in the results. If each item in your data
+  source contains more information, then you won't be able to access it. See the code of `<address-autocomplete>`
+  element in the demo folder for a complete example.
+
+  Another important thing to point out is related to the height of each suggestion item in the results. The height of
+  the suggestion template changes dynamically depending on the height of a suggestion item. However, the following
+  assumptions were made:
+  - All suggestions items have the same height
+  - The height of each item is fixed and can be determined at any time. For example, if you want to use images in the
+  results, make sure they have a placeholder or a fixed height.
 
   ### Styling
 

--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -90,17 +90,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     :host[suggestions-in-overlay="true"] #suggestionsWrapper {
     }
 
+    paper-item,
     :host ::content paper-item {
       position: relative;
       line-height: 18px;
     }
 
+    paper-item:hover,
     :host ::content paper-item:hover {
       background: #eee;
       color: #333;
       cursor: pointer;
     }
 
+    paper-item.active,
     :host ::content paper-item.active {
       background: #eee;
       color: #333;
@@ -293,14 +296,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        */
       minLength: {
         value: 1
-      },
-
-      /**
-       * Indicates if shadow dom is used
-       */
-      useShadowDom: {
-        type: Boolean,
-        value: false
       },
 
       /**
@@ -592,10 +587,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     _getItems: function () {
-      var supportsShadow = Boolean(Element.prototype.createShadowRoot);
-      var useShadow = this.useShadowDom;
-      if (useShadow && supportsShadow) return this.shadowRoot.querySelectorAll('paper-item');
-      else return this.querySelectorAll('paper-item');
+      return this.$.suggestionsWrapper.querySelectorAll('paper-item');
     },
 
     _emptyItems: function () {

--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -343,7 +343,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       /**
        * `_suggestions` Array with the actual suggestions to display
        */
-      _suggestions: Array,
+      _suggestions: {
+        type: Array,
+        observer: '_onSuggestionsChanged'
+      },
 
       _currentIndex: {
         value: -1
@@ -482,12 +485,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _handleSuggestions: function (event) {
       if (!this.remoteSource) this._createSuggestions(event);
       else this._remoteSuggestions(event);
-
-      var firstSuggestionElement = this.$.suggestionsWrapper.querySelector('paper-item');
-      if (firstSuggestionElement !== null) {
-        // Update maxHeight of suggestions wrapper depending on the height of each item result
-        this._itemHeight = firstSuggestionElement.offsetHeight;
-      }
     },
 
     _remoteSuggestions: function (event) {
@@ -499,7 +496,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       if (value && value.length >= this.minLength) {
         this._fireEvent(option, 'change');
-        this._renderSuggestions(this._suggestions);
       } else {
         this.$.clear.style.display = 'none';
         this._suggestions = [];
@@ -512,7 +508,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this._currentIndex = -1;
         this._scrollIndex = 0;
         if (!this.disableShowClear) this.$.clear.style.display = 'block';
-        this._showSuggestionsWrapper();
       } else {
         this.$.clear.style.display = 'none';
         this._suggestions = [];
@@ -523,8 +518,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._currentIndex = -1;
       this._scrollIndex = 0;
       var value = event.target.value;
-      var minLength = this.minLength;
-      if (value && value.length >= minLength) {
+      if (value && value.length >= this.minLength) {
         value = value.toLowerCase();
 
         // Shows the clear button.
@@ -534,19 +528,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (this.source && this.source.length > 0) {
           // Call queryFn. User can override queryFn() to provide custom search functionality
           this._suggestions = this.queryFn(this.source, value);
-
-          this._renderSuggestions(this._suggestions);
-
-          if (this._suggestions.length > 0) {
-            this._showSuggestionsWrapper();
-          } else {
-            this._hideSuggestionsWrapper();
-          }
         }
       } else {
         this.$.clear.style.display = 'none';
         this._suggestions = [];
-        this._renderSuggestions(this._suggestions);
       }
     },
 
@@ -569,6 +554,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         suggestionsContainer.appendChild(clone.root);
       }.bind(this));
+    },
+
+    /**
+     * Listener to changes to _suggestions state
+     */
+    _onSuggestionsChanged: function () {
+      this._renderSuggestions(this._suggestions);
+
+      if (this._suggestions.length > 0) {
+        this._showSuggestionsWrapper();
+      } else {
+        this._hideSuggestionsWrapper();
+      }
+
+      var firstSuggestionElement = this.$.suggestionsWrapper.querySelector('paper-item');
+      if (firstSuggestionElement !== null) {
+        // Update maxHeight of suggestions wrapper depending on the height of each item result
+        this._itemHeight = firstSuggestionElement.offsetHeight;
+      }
     },
 
     _selection: function (index) {

--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -24,6 +24,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   paper-autocomplete extends earlier efforts such as this (https://github.com/rodo1111/paper-input-autocomplete)
   to provide keyboard support, remote binding and results scrolling.
 
+  ### Custom search
+  This component has the public method `queryFn` that is called in each key stroke and it is responsible to query
+  all items in the `source` and returns only those items that matches certain filtering criteria. By default, this
+  component search for items that start with the recent query (case insensitive).
+  You can override this behavior providing your own query function, as long as these two requirements are fulfill:
+  - The query function is synchronous.
+  - The API is respected and the method always return an Array.
+
   ### Styling
 
   `<paper-autocomplete>` provides the following custom properties and mixins
@@ -461,28 +469,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var minLength = this.minLength;
       if (value && value.length >= minLength) {
         value = value.toLowerCase();
+
         // Shows the clear button.
         if (!this.disableShowClear) this.$.clear.style.display = 'block';
+
         // Search for the word in the source properties.
         if (this.source && this.source.length > 0) {
-          this._suggestions = [];
-          var length = this.source.length;
-          var objText, objValue;
-          for (var i = 0; i < length; i++) {
-            var item = this.source[i];
-            if (typeof item === 'object') {
-              objText = item[this.textProperty];
-              objValue = item[this.valueProperty]
-            } else {
-              objText = item.toString();
-              objValue = objText;
-            }
-
-            if (objText.toLowerCase().indexOf(value) === 0) {
-              // Adds the item to the suggestions list.
-              this.push('_suggestions', {text: objText, value: objValue});
-            }
-          }
+          // Call queryFn. User can override queryFn() to provide custom search functionality
+          this._suggestions = this.queryFn(this.source, value);
 
           if (this._suggestions.length > 0) {
             this._showSuggestionsWrapper();
@@ -746,6 +740,36 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         self.$.clear.style.display = 'none';
         self._hideSuggestionsWrapper();
       }, 300);
+    },
+
+    /**
+     * Query function is called on each keystroke to query the data source and returns the suggestions that matches
+     * with the filtering logic included.
+     * @param {Array} datasource An array containing all items before filtering
+     * @param {string} query Current value in the input field
+     * @returns {Array} an array containing only those items in the data source that matches the filtering logic.
+     */
+    queryFn: function (datasource, query) {
+      var queryResult = [];
+
+      datasource.forEach(function (item) {
+        var objText, objValue;
+
+        if (typeof item === 'object') {
+          objText = item[this.textProperty];
+          objValue = item[this.valueProperty]
+        } else {
+          objText = item.toString();
+          objValue = objText;
+        }
+
+        if (objText.toLowerCase().indexOf(query) === 0) {
+          // Adds the item to the suggestions list.
+          queryResult.push({text: objText, value: objValue});
+        }
+      }.bind(this));
+
+      return queryResult;
     }
 
     /**

--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -90,6 +90,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   `--paper-input-container-focus-color` | sets the components input container focus color | #2196f3
   `--paper-item-min-height` | paper item min height | `{}`
 
+  ### Accessibility
+
+  This component is friendly with screen readers (tested only with VoiceOver and NVDA in Windows): current selection
+  and active suggestion are announced.
+
   @demo demo/index.html
 -->
 

--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -56,12 +56,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   ```
   <paper-autocomplete>
     <template autocomplete-custom-template>
-      <div on-tap="_onSelect">
-        <paper-item id$="[[_getSuggestionId(index)]]" role="option" aria-selected="false">
-          YOUR CUSTOM TEMPLATE
-          <paper-ripple></paper-ripple>
-        </paper-item>
-      </div>
+      <paper-item on-tap="_onSelect" id$="[[_getSuggestionId(index)]]" role="option" aria-selected="false">
+        YOUR CUSTOM TEMPLATE
+        <paper-ripple></paper-ripple>
+      </paper-item>
     </template>
   </paper-autocomplete>
   ```
@@ -69,12 +67,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   You need to always maintain this structure. Then you can customize the content of paper-item. These are the reasons
   why you need to maintain it:
 
-  - The wrapper with `_onSelect` it is very important because it will notify the `autocomplete` component when user
-  selects one item.
-  - `id`, `role` and `aria-selected` need to be there for accessibility reasons.
+  - `_onSelect` it is very important because it will notify the `autocomplete` component when user selects one item.
+  If you don't add this option, when user clicks in one of the items, nothing will happen.
+  - `id`, `role` and `aria-selected` need to be there for accessibility reasons. If you don't set them, the component
+  will continue working but it will not be accessible for user with disabilities.
 
-  It is important to note that methods `_onSelect` and `_getSuggestionId` do not need to be implemented. They are part
-  of the logic of `paper-autocomplete`.
+  It is important to clarify that methods `_onSelect` and `_getSuggestionId` do not need to be implemented. They are
+  part of the logic of `paper-autocomplete`.
 
   When providing your own custom template, you might also need to provide your own custom search function. The reason
   for that is that the default search function only exposes text and value in the results. If each item in your data
@@ -205,18 +204,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <span id="autocompleteStatus" role="status" class="sr-only">[[_textOfHighlightedElement]]</span>
     </div>
 
-    <paper-material elevation="1" id="suggestionsWrapper" role="listbox">
-      <!-- suggestions will be render here -->
+    <paper-material elevation="1">
+      <div id="suggestionsWrapper" role="listbox">
+        <!-- suggestions will be render here -->
+      </div>
     </paper-material>
 
     <!-- Default suggestion template -->
     <template id="defaultTemplate">
-      <div on-tap="_onSelect">
-        <paper-item id$="[[_getSuggestionId(index)]]" role="option" aria-selected="false">
-          <div>[[_getItemText(item)]]</div>
-          <paper-ripple></paper-ripple>
-        </paper-item>
-      </div>
+      <paper-item id$="[[_getSuggestionId(index)]]" role="option" aria-selected="false" on-tap="_onSelect">
+        <div>[[_getItemText(item)]]</div>
+        <paper-ripple></paper-ripple>
+      </paper-item>
     </template>
 
     <!-- Custom template -->
@@ -726,7 +725,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           this._scrollIndex = this._scrollIndex + modifier;
 
           var scrollTop = (this._scrollIndex * this._itemHeight);
-          var paperMaterial = this.querySelector('paper-material');
+          var paperMaterial = this.$.suggestionsWrapper;
           paperMaterial.scrollTop = scrollTop;
         }
       },

--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -357,7 +357,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         value: false
       }
     },
+
     // Element Lifecycle
+
     ready: function () {
       this._value = this.value;
     },
@@ -475,6 +477,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               objText = item.toString();
               objValue = objText;
             }
+
             if (objText.toLowerCase().indexOf(value) === 0) {
               // Adds the item to the suggestions list.
               this.push('_suggestions', {text: objText, value: objValue});
@@ -643,7 +646,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._fireEvent(option, 'focus');
     },
 
-    /* public */
+    /**
+     * Generate a suggestion id for a certain index
+     * @param {number} index Position of the element in the suggestions list
+     * @returns {string} a unique id based on the _idItemSeed and the position of that element in the suggestions popup
+     * @private
+     */
+    _getSuggestionId: function (index) {
+      return this._idItemSeed + '-' + index;
+    },
+
+    /****************************
+     * PUBLIC
+     ****************************/
+
     /**
      * Gets the current value of the input
      * @returns {String}
@@ -730,16 +746,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         self.$.clear.style.display = 'none';
         self._hideSuggestionsWrapper();
       }, 300);
-    },
-
-    /**
-     * Generate a suggestion id for a certain index
-     * @param {number} index Position of the element in the suggestions list
-     * @returns {string} a unique id based on the _idItemSeed and the position of that element in the suggestions popup
-     * @private
-     */
-    _getSuggestionId: function (index) {
-      return this._idItemSeed + '-' + index;
     }
 
     /**

--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -349,12 +349,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         value: 0
       },
 
+      /**
+       * Max number of suggestions to be displayed without scrolling
+       */
       _maxViewableItems: {
         value: 7
       },
 
+      /**
+       * Height of each suggestion element in pixels
+       */
       _itemHeight: {
-        value: 36
+        value: 36,
+        observer: '_itemHeightChanged'
       },
 
       // TODO: check if we need _value and _text properties. It seems they can be removed
@@ -471,6 +478,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _handleSuggestions: function (event) {
       if (!this.remoteSource) this._createSuggestions(event);
       else this._remoteSuggestions(event);
+
+      var firstSuggestionElement = this.$.suggestionsWrapper.querySelector('paper-item');
+      if (firstSuggestionElement !== null) {
+        // Update maxHeight of suggestions wrapper depending on the height of each item result
+        this._itemHeight = firstSuggestionElement.offsetHeight;
+      }
     },
 
     _remoteSuggestions: function (event) {
@@ -720,6 +733,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      */
     _getSuggestionId: function (index) {
       return this._idItemSeed + '-' + index;
+    },
+
+    /**
+     * When item height is changed, the maxHeight of the suggestionWrapper need to be updated
+     */
+    _itemHeightChanged: function () {
+      this.$.suggestionsWrapper.style.maxHeight = this._itemHeight * this._maxViewableItems + 'px';
     },
 
     /****************************

--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -224,753 +224,760 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </dom-module>
 
 <script>
-  Polymer({
-    is: 'paper-autocomplete',
+  (function () {
+    var DIRECTION = {
+      UP: 'up',
+      DOWN: 'down'
+    };
 
-    behaviors: [
-      Polymer.Templatizer
-    ],
+    Polymer({
+      is: 'paper-autocomplete',
 
-    properties: {
-      /**
-       * `autoValidate` Set to true to auto-validate the input value.
-       */
-      autoValidate: {
-        type: Boolean,
-        value: false
-      },
+      behaviors: [
+        Polymer.Templatizer
+      ],
 
-      /**
-       * `errorMessage` The error message to display when the input is invalid.
-       */
-      errorMessage: {
-        type: String
-      },
+      properties: {
+        /**
+         * `autoValidate` Set to true to auto-validate the input value.
+         */
+        autoValidate: {
+          type: Boolean,
+          value: false
+        },
 
-      /**
-       * `label` Text to display as the input label
-       */
-      label: String,
+        /**
+         * `errorMessage` The error message to display when the input is invalid.
+         */
+        errorMessage: {
+          type: String
+        },
 
-      /**
-       * `noLabelFloat` Set to true to disable the floating label.
-       */
-      noLabelFloat: {
-        type: Boolean,
-        value: false
-      },
+        /**
+         * `label` Text to display as the input label
+         */
+        label: String,
 
-      /**
-       * `alwaysFloatLabel` Set to true to always float label
-       */
-      alwaysFloatLabel: {
-        type: Boolean,
-        value: false
-      },
+        /**
+         * `noLabelFloat` Set to true to disable the floating label.
+         */
+        noLabelFloat: {
+          type: Boolean,
+          value: false
+        },
 
-      /**
-       * `required` Set to true to mark the input as required.
-       */
-      required: {
-        type: Boolean,
-        value: false
-      },
+        /**
+         * `alwaysFloatLabel` Set to true to always float label
+         */
+        alwaysFloatLabel: {
+          type: Boolean,
+          value: false
+        },
 
-      /**
-       * `source` Array of objects with the options to execute the autocomplete feature
-       */
-      source: Array,
+        /**
+         * `required` Set to true to mark the input as required.
+         */
+        required: {
+          type: Boolean,
+          value: false
+        },
 
-      /**
-       * Property of local datasource to as the text property
-       */
-      textProperty: {
-        type: String,
-        value: 'text'
-      },
+        /**
+         * `source` Array of objects with the options to execute the autocomplete feature
+         */
+        source: Array,
 
-      /**
-       * Property of local datasource to as the value property
-       */
-      valueProperty: {
-        type: String,
-        value: 'value'
-      },
+        /**
+         * Property of local datasource to as the text property
+         */
+        textProperty: {
+          type: String,
+          value: 'text'
+        },
 
-      /**
-       * `value` Selected object from the suggestions
-       */
-      value: {
-        type: Object,
-        notify: true
-      },
+        /**
+         * Property of local datasource to as the value property
+         */
+        valueProperty: {
+          type: String,
+          value: 'value'
+        },
 
-      /**
-       * The current/selected text of the input
-       */
-      text: {
-        type: String,
-        notify: true,
-        value: ''
-      },
+        /**
+         * `value` Selected object from the suggestions
+         */
+        value: {
+          type: Object,
+          notify: true
+        },
 
-      /**
-       * Disable showing the clear X button
-       */
-      disableShowClear: {
-        type: Boolean,
-        value: false
-      },
+        /**
+         * The current/selected text of the input
+         */
+        text: {
+          type: String,
+          notify: true,
+          value: ''
+        },
 
-      /**
-       * Binds to a remote data source
-       */
-      remoteSource: {
-        type: Boolean,
-        value: false
-      },
+        /**
+         * Disable showing the clear X button
+         */
+        disableShowClear: {
+          type: Boolean,
+          value: false
+        },
 
-      /**
-       * Event type separator
-       */
-      eventNamespace: {
-        type: String,
-        value: '-'
-      },
+        /**
+         * Binds to a remote data source
+         */
+        remoteSource: {
+          type: Boolean,
+          value: false
+        },
 
-      /**
-       * Minimum length to trigger suggestions
-       */
-      minLength: {
-        value: 1
-      },
+        /**
+         * Event type separator
+         */
+        eventNamespace: {
+          type: String,
+          value: '-'
+        },
 
-      /**
-       * `pattern` Pattern to validate input field
-       */
-      pattern: String,
+        /**
+         * Minimum length to trigger suggestions
+         */
+        minLength: {
+          value: 1
+        },
 
-      /**
-       * allowedPattern` allowedPattern to validate input field
-       */
-      allowedPattern: String,
+        /**
+         * `pattern` Pattern to validate input field
+         */
+        pattern: String,
 
-      /**
-       * Set to `true` to show a character counter.
-       */
-      charCounter: {
-        type: Boolean,
-        value: false
-      },
+        /**
+         * allowedPattern` allowedPattern to validate input field
+         */
+        allowedPattern: String,
 
-      /**
-       * The maximum length of the input value.
-       */
-      maxlength: {
-        type: Number
-      },
+        /**
+         * Set to `true` to show a character counter.
+         */
+        charCounter: {
+          type: Boolean,
+          value: false
+        },
 
-      /**
-       * Reference to the current suggestion template
-       */
-      _suggestionTemplate: {
-        type: Object,
-        value: function () {
-          var customTemplate = this.getEffectiveChildren();
+        /**
+         * The maximum length of the input value.
+         */
+        maxlength: {
+          type: Number
+        },
 
-          return customTemplate.length > 0 ? customTemplate[0] : this.$.defaultTemplate;
+        /**
+         * Reference to the current suggestion template
+         */
+        _suggestionTemplate: {
+          type: Object,
+          value: function () {
+            var customTemplate = this.getEffectiveChildren();
+
+            return customTemplate.length > 0 ? customTemplate[0] : this.$.defaultTemplate;
+          }
+        },
+
+        /**
+         * `_suggestions` Array with the actual suggestions to display
+         */
+        _suggestions: {
+          type: Array,
+          observer: '_onSuggestionsChanged'
+        },
+
+        _currentIndex: {
+          value: -1
+        },
+
+        _scrollIndex: {
+          value: 0
+        },
+
+        /**
+         * Max number of suggestions to be displayed without scrolling
+         */
+        _maxViewableItems: {
+          value: 7
+        },
+
+        /**
+         * Height of each suggestion element in pixels
+         */
+        _itemHeight: {
+          value: 36,
+          observer: '_itemHeightChanged'
+        },
+
+        // TODO: check if we need _value and _text properties. It seems they can be removed
+        _value: {
+          value: undefined
+        },
+
+        _text: {
+          value: undefined
+        },
+
+        /**
+         * This value is used as a base to generate unique individual ids that need to be added to each suggestion for
+         * accessibility reasons.
+         */
+        _idItemSeed: {
+          type: String,
+          value: 'aria-' + new Date().getTime() + '-' + (Math.floor(Math.random() * 1000)),
+          readOnly: true
+        },
+
+        /**
+         * Id of the DOM element currently highlighted
+         */
+        _idElementHighlighted: {
+          type: String,
+          value: ''
+        },
+
+        /**
+         * Text value of the current highlighted value to be announce to the screen reader
+         */
+        _textOfHighlightedElement: {
+          type: String
+        },
+
+        /**
+         * `true` if the suggestions list is opened, `false otherwise`
+         */
+        _isSuggestionsOpened: {
+          type: Boolean,
+          value: false
         }
       },
 
-      /**
-       * `_suggestions` Array with the actual suggestions to display
-       */
-      _suggestions: {
-        type: Array,
-        observer: '_onSuggestionsChanged'
+      // Element Lifecycle
+
+      ready: function () {
+        this._value = this.value;
+
+        // This is important to be able to access component methods inside the templates used with Templatizer
+        this.dataHost = this;
+
+        // templatize must be called once before stamp is called
+        this.templatize(this._suggestionTemplate);
       },
 
-      _currentIndex: {
-        value: -1
+      detached: function () {
+        this.cancelDebouncer('_onSuggestionChanged');
       },
 
-      _scrollIndex: {
-        value: 0
+      listeners: {
+        'input.focus': '_onFocus',
+        'input.blur': '_onBlur'
       },
 
-      /**
-       * Max number of suggestions to be displayed without scrolling
-       */
-      _maxViewableItems: {
-        value: 7
-      },
-
-      /**
-       * Height of each suggestion element in pixels
-       */
-      _itemHeight: {
-        value: 36,
-        observer: '_itemHeightChanged'
-      },
-
-      // TODO: check if we need _value and _text properties. It seems they can be removed
-      _value: {
-        value: undefined
-      },
-
-      _text: {
-        value: undefined
-      },
+      // Element Behavior
 
       /**
-       * This value is used as a base to generate unique individual ids that need to be added to each suggestion for
-       * accessibility reasons.
+       * Clears the input text
        */
-      _idItemSeed: {
-        type: String,
-        value: 'aria-' + new Date().getTime() + '-' + (Math.floor(Math.random() * 1000)),
-        readOnly: true
-      },
+      _clear: function () {
+        var option = {
+          text: this.text,
+          value: this.value
+        };
 
-      /**
-       * Id of the DOM element currently highlighted
-       */
-      _idElementHighlighted: {
-        type: String,
-        value: ''
-      },
+        this.value = null;
+        this._value = null;
+        this.text = '';
+        this._text = '';
 
-      /**
-       * Text value of the current highlighted value to be announce to the screen reader
-       */
-      _textOfHighlightedElement: {
-        type: String
-      },
-
-      /**
-       * `true` if the suggestions list is opened, `false otherwise`
-       */
-      _isSuggestionsOpened: {
-        type: Boolean,
-        value: false
-      }
-    },
-
-    // Element Lifecycle
-
-    ready: function () {
-      this._value = this.value;
-
-      // This is important to be able to access component methods inside the templates used with Templatizer
-      this.dataHost = this;
-
-      // templatize must be called once before stamp is called
-      this.templatize(this._suggestionTemplate);
-    },
-
-    detached: function () {
-      this.cancelDebouncer('_onSuggestionChanged');
-    },
-
-    listeners: {
-      'input.focus': '_onFocus',
-      'input.blur': '_onBlur'
-    },
-
-    // Element Behavior
-
-    /**
-     * Clears the input text
-     */
-    _clear: function () {
-      var option = {
-        text: this.text,
-        value: this.value
-      };
-
-      this.value = null;
-      this._value = null;
-      this.text = '';
-      this._text = '';
-
-      this.$.clear.style.display = 'none';
-
-      this._hideSuggestionsWrapper();
-      this._emptyItems();
-
-      this._fireEvent(option, 'reset');
-    },
-
-    /**
-     * Get the text property from the suggestion
-     * @param {Object} suggestion The suggestion item
-     * @return {String}
-     */
-    _getItemText: function (suggestion) {
-      return suggestion[this.textProperty];
-    },
-
-    /**
-     * Show the suggestions wrapper
-     */
-    _showSuggestionsWrapper: function () {
-      this.$.suggestionsWrapper.style.display = 'block';
-      this._isSuggestionsOpened = true;
-    },
-
-    /**
-     * Hide the suggestions wrapper
-     */
-    _hideSuggestionsWrapper: function () {
-      this.$.suggestionsWrapper.style.display = 'none';
-      this._isSuggestionsOpened = false;
-      this._idElementHighlighted = '';
-      this._textOfHighlightedElement = '';
-    },
-
-    _handleSuggestions: function (event) {
-      if (!this.remoteSource) this._createSuggestions(event);
-      else this._remoteSuggestions(event);
-    },
-
-    _remoteSuggestions: function (event) {
-      var value = event.target.value;
-      var option = {
-        text: this.text,
-        value: value
-      };
-
-      if (value && value.length >= this.minLength) {
-        this._fireEvent(option, 'change');
-      } else {
         this.$.clear.style.display = 'none';
-        this._suggestions = [];
-      }
-    },
 
-    _bindSuggestions: function (arr) {
-      if (arr.length && arr.length > 0) {
-        this._suggestions = arr;
+        this._hideSuggestionsWrapper();
+        this._emptyItems();
+
+        this._fireEvent(option, 'reset');
+      },
+
+      /**
+       * Get the text property from the suggestion
+       * @param {Object} suggestion The suggestion item
+       * @return {String}
+       */
+      _getItemText: function (suggestion) {
+        return suggestion[this.textProperty];
+      },
+
+      /**
+       * Show the suggestions wrapper
+       */
+      _showSuggestionsWrapper: function () {
+        this.$.suggestionsWrapper.style.display = 'block';
+        this._isSuggestionsOpened = true;
+      },
+
+      /**
+       * Hide the suggestions wrapper
+       */
+      _hideSuggestionsWrapper: function () {
+        this.$.suggestionsWrapper.style.display = 'none';
+        this._isSuggestionsOpened = false;
+        this._idElementHighlighted = '';
+        this._textOfHighlightedElement = '';
+      },
+
+      _handleSuggestions: function (event) {
+        if (!this.remoteSource) this._createSuggestions(event);
+        else this._remoteSuggestions(event);
+      },
+
+      _remoteSuggestions: function (event) {
+        var value = event.target.value;
+        var option = {
+          text: this.text,
+          value: value
+        };
+
+        if (value && value.length >= this.minLength) {
+          this._fireEvent(option, 'change');
+        } else {
+          this.$.clear.style.display = 'none';
+          this._suggestions = [];
+        }
+      },
+
+      _bindSuggestions: function (arr) {
+        if (arr.length && arr.length > 0) {
+          this._suggestions = arr;
+          this._currentIndex = -1;
+          this._scrollIndex = 0;
+          if (!this.disableShowClear) this.$.clear.style.display = 'block';
+        } else {
+          this.$.clear.style.display = 'none';
+          this._suggestions = [];
+        }
+      },
+
+      _createSuggestions: function (event) {
         this._currentIndex = -1;
         this._scrollIndex = 0;
-        if (!this.disableShowClear) this.$.clear.style.display = 'block';
-      } else {
-        this.$.clear.style.display = 'none';
-        this._suggestions = [];
-      }
-    },
+        var value = event.target.value;
+        if (value && value.length >= this.minLength) {
+          value = value.toLowerCase();
 
-    _createSuggestions: function (event) {
-      this._currentIndex = -1;
-      this._scrollIndex = 0;
-      var value = event.target.value;
-      if (value && value.length >= this.minLength) {
-        value = value.toLowerCase();
+          // Shows the clear button.
+          if (!this.disableShowClear) this.$.clear.style.display = 'block';
 
-        // Shows the clear button.
-        if (!this.disableShowClear) this.$.clear.style.display = 'block';
-
-        // Search for the word in the source properties.
-        if (this.source && this.source.length > 0) {
-          // Call queryFn. User can override queryFn() to provide custom search functionality
-          this._suggestions = this.queryFn(this.source, value);
-        }
-      } else {
-        this.$.clear.style.display = 'none';
-        this._suggestions = [];
-      }
-    },
-
-    /**
-     * Render suggestions in the suggestionsWrapper container
-     * @param {Array} suggestions An array containing the suggestions to be rendered. This value is not optional, so
-     *    in case no suggestions need to be rendered, you should either not call this method or provide an empty array.
-     */
-    _renderSuggestions: function (suggestions) {
-      var suggestionsContainer = this.$.suggestionsWrapper;
-
-      suggestionsContainer.innerHTML = '';
-
-      suggestions.forEach(function (result, index) {
-        // clone the template and bind with the model
-        var clone = this.stamp({
-          item: result,
-          index: index
-        });
-
-        suggestionsContainer.appendChild(clone.root);
-      }.bind(this));
-    },
-
-    /**
-     * Listener to changes to _suggestions state
-     */
-    _onSuggestionsChanged: function () {
-      this.debounce('_onSuggestionChanged', function () {
-        this._renderSuggestions(this._suggestions);
-
-        if (this._suggestions.length > 0) {
-          this._showSuggestionsWrapper();
+          // Search for the word in the source properties.
+          if (this.source && this.source.length > 0) {
+            // Call queryFn. User can override queryFn() to provide custom search functionality
+            this._suggestions = this.queryFn(this.source, value);
+          }
         } else {
-          this._hideSuggestionsWrapper();
+          this.$.clear.style.display = 'none';
+          this._suggestions = [];
         }
+      },
 
-        Polymer.dom.flush();
+      /**
+       * Render suggestions in the suggestionsWrapper container
+       * @param {Array} suggestions An array containing the suggestions to be rendered. This value is not optional, so
+       *    in case no suggestions need to be rendered, you should either not call this method or provide an empty array.
+       */
+      _renderSuggestions: function (suggestions) {
+        var suggestionsContainer = this.$.suggestionsWrapper;
 
-        var firstSuggestionElement = this.$.suggestionsWrapper.querySelector('paper-item');
-        if (firstSuggestionElement !== null) {
-          // Update maxHeight of suggestions wrapper depending on the height of each item result
-          this._itemHeight = firstSuggestionElement.offsetHeight;
-        }
-      }, 100);
-    },
+        suggestionsContainer.innerHTML = '';
 
-    _selection: function (index) {
-      var selectedOption = this._suggestions[index];
-      var self = this;
-      this.text = selectedOption[this.textProperty];
-      this.value = selectedOption[this.valueProperty];
-      this._value = this.value;
-      this._text = this.text;
-      this.$.clear.style.display = 'none';
-      this._emptyItems();
-      this._fireEvent(selectedOption, 'selected');
-
-      setTimeout(function () {
-        self._hideSuggestionsWrapper();
-      }, 300);
-    },
-
-    _getItems: function () {
-      return this.$.suggestionsWrapper.querySelectorAll('paper-item');
-    },
-
-    _emptyItems: function () {
-      this._suggestions = [];
-    },
-
-    _getId: function () {
-      var id = this.getAttribute('id');
-      if (!id) id = this.dataset.id;
-      return id;
-    },
-
-    _removeActive: function (items) {
-      for (var i = 0; i < items.length; i++) {
-        items[i].classList.remove('active');
-        items[i].setAttribute('aria-selected', "false");
-      }
-    },
-
-    _keydown: function () {
-      var items = this._getItems();
-      var length = items.length;
-      length--;
-      if (this._currentIndex < length) {
-        this._removeActive(items);
-        this._currentIndex++;
-        items[this._currentIndex].classList.add('active');
-        items[this._currentIndex].setAttribute('aria-selected', "true");
-        this._idElementHighlighted = items[this._currentIndex].id;
-        this._textOfHighlightedElement = this._suggestions[this._currentIndex][this.textProperty];
-        this._scroll('down');
-      }
-    },
-
-    _keyup: function () {
-      var items = this._getItems();
-      if (this._currentIndex > 0) {
-        this._removeActive(items);
-        this._currentIndex--;
-        items[this._currentIndex].classList.add('active');
-        items[this._currentIndex].setAttribute('aria-selected', "true");
-        this._idElementHighlighted = items[this._currentIndex].id;
-        this._textOfHighlightedElement = this._suggestions[this._currentIndex][this.textProperty];
-        this._scroll('up');
-      }
-    },
-
-    _keyenter: function () {
-      if (this.$.suggestionsWrapper.style.display == 'block' && this._currentIndex > -1) {
-        var index = this._currentIndex;
-        this._selection(index);
-      }
-    },
-
-    /**
-     * Move scroll (if needed) to display the active element in the suggestions list.
-     * @param {string} direction Direction to scroll. Possible values are `'up'` and `'down'`.
-     */
-    _scroll: function (direction) {
-      var modifier, isSelectedOutOfView;
-
-      var viewIndex = this._currentIndex - this._scrollIndex;
-
-      if (direction === 'up') {
-        modifier = -1;
-        isSelectedOutOfView = viewIndex < 0;
-      } else {
-        modifier = +1;
-        isSelectedOutOfView = viewIndex >= this._maxViewableItems
-      }
-
-      // Only when the current active element is out of view, we need to move the position of the scroll
-      if (isSelectedOutOfView) {
-        this._scrollIndex = this._scrollIndex + modifier;
-
-        var scrollTop = (this._scrollIndex * this._itemHeight);
-        var paperMaterial = this.querySelector('paper-material');
-        paperMaterial.scrollTop = scrollTop;
-      }
-    },
-
-    _fireEvent: function (option, evt) {
-      var id = this._getId();
-      var event = 'autocomplete' + this.eventNamespace + evt;
-
-      this.fire(event, {
-        id: id,
-        value: option[this.valueProperty] || option.value,
-        text: option[this.textProperty] || option.text,
-        target: this,
-        option: option
-      });
-    },
-
-    _onKeypress: function (event) {
-      var which = event.which;
-
-      if (which === 40) {
-        this._keydown();
-      } else if (which === 38) {
-        this._keyup(event);
-      } else if (which === 13) {
-        this._keyenter();
-      } else {
-        this._handleSuggestions(event);
-      }
-    },
-
-    _onSelect: function (event) {
-      var index = event.model.index;
-      this._selection(index);
-    },
-
-    _onBlur: function () {
-      var self = this;
-      var option = {
-        text: this.text,
-        value: this.value
-      };
-
-      this._fireEvent(option, 'blur');
-
-      setTimeout(function () {
-        self.$.clear.style.display = 'none';
-        self._hideSuggestionsWrapper();
-      }, 300);
-    },
-
-    _onFocus: function () {
-      var option = {
-        text: this.text,
-        value: this.value
-      };
-
-      this._fireEvent(option, 'focus');
-    },
-
-    /**
-     * Generate a suggestion id for a certain index
-     * @param {number} index Position of the element in the suggestions list
-     * @returns {string} a unique id based on the _idItemSeed and the position of that element in the suggestions popup
-     * @private
-     */
-    _getSuggestionId: function (index) {
-      return this._idItemSeed + '-' + index;
-    },
-
-    /**
-     * When item height is changed, the maxHeight of the suggestionWrapper need to be updated
-     */
-    _itemHeightChanged: function () {
-      this.$.suggestionsWrapper.style.maxHeight = this._itemHeight * this._maxViewableItems + 'px';
-    },
-
-    /****************************
-     * PUBLIC
-     ****************************/
-
-    /**
-     * Gets the current value of the input
-     * @returns {String}
-     */
-    getValue: function () {
-      return this.value;
-    },
-
-    /**
-     * Gets the current text/value option of the input
-     * @returns {Object}
-     */
-    getOption: function () {
-      return {
-        text: this.text,
-        value: this.value
-      };
-    },
-
-    /**
-     * Sets the current text/value option of the input
-     * @param {Object} option
-     */
-    setOption: function (option) {
-      this.text = option[this.textProperty || 'text'];
-      this.value = option[this.valueProperty || 'value'];
-    },
-
-    /**
-     * Disables the input
-     */
-    disable: function () {
-      this.disabled = true;
-      this.$.input.disabled = true;
-    },
-
-    /**
-     * Enables the input
-     */
-    enable: function () {
-      this.disabled = false;
-      this.$.input.disabled = false;
-    },
-
-    /**
-     * Sets the component's current suggestions
-     * @param {Array} arr
-     */
-    suggestions: function (arr) {
-      this._bindSuggestions(arr);
-    },
-
-    /**
-     * Validates the input
-     * @returns {Boolean}
-     */
-    validate: function () {
-      return this.$.input.validate();
-    },
-
-    /**
-     * Clears the current input
-     */
-    clear: function () {
-      this._value = '';
-      this._text = '';
-      this._clear();
-    },
-
-    /**
-     * Resets the current input
-     */
-    reset: function () {
-      this._clear();
-    },
-
-    /**
-     * Hides the suggestions popup
-     */
-    hideSuggestions: function () {
-      var self = this;
-
-      setTimeout(function () {
-        self.$.clear.style.display = 'none';
-        self._hideSuggestionsWrapper();
-      }, 300);
-    },
-
-    /**
-     * Query function is called on each keystroke to query the data source and returns the suggestions that matches
-     * with the filtering logic included.
-     * @param {Array} datasource An array containing all items before filtering
-     * @param {string} query Current value in the input field
-     * @returns {Array} an array containing only those items in the data source that matches the filtering logic.
-     */
-    queryFn: function (datasource, query) {
-      var queryResult = [];
-
-      datasource.forEach(function (item) {
-        var objText, objValue;
-
-        if (typeof item === 'object') {
-          objText = item[this.textProperty];
-          objValue = item[this.valueProperty]
-        } else {
-          objText = item.toString();
-          objValue = objText;
-        }
-
-        if (objText.toLowerCase().indexOf(query) === 0) {
-          // NOTE: the structure of the result object matches with the current template. For custom templates, you
-          // might need to return more data
-          queryResult.push({
-            text: objText,
-            value: objValue
+        suggestions.forEach(function (result, index) {
+          // clone the template and bind with the model
+          var clone = this.stamp({
+            item: result,
+            index: index
           });
+
+          suggestionsContainer.appendChild(clone.root);
+        }.bind(this));
+      },
+
+      /**
+       * Listener to changes to _suggestions state
+       */
+      _onSuggestionsChanged: function () {
+        this.debounce('_onSuggestionChanged', function () {
+          this._renderSuggestions(this._suggestions);
+
+          if (this._suggestions.length > 0) {
+            this._showSuggestionsWrapper();
+          } else {
+            this._hideSuggestionsWrapper();
+          }
+
+          Polymer.dom.flush();
+
+          var firstSuggestionElement = this.$.suggestionsWrapper.querySelector('paper-item');
+          if (firstSuggestionElement !== null) {
+            // Update maxHeight of suggestions wrapper depending on the height of each item result
+            this._itemHeight = firstSuggestionElement.offsetHeight;
+          }
+        }, 100);
+      },
+
+      _selection: function (index) {
+        var selectedOption = this._suggestions[index];
+        var self = this;
+        this.text = selectedOption[this.textProperty];
+        this.value = selectedOption[this.valueProperty];
+        this._value = this.value;
+        this._text = this.text;
+        this.$.clear.style.display = 'none';
+        this._emptyItems();
+        this._fireEvent(selectedOption, 'selected');
+
+        setTimeout(function () {
+          self._hideSuggestionsWrapper();
+        }, 300);
+      },
+
+      _getItems: function () {
+        return this.$.suggestionsWrapper.querySelectorAll('paper-item');
+      },
+
+      _emptyItems: function () {
+        this._suggestions = [];
+      },
+
+      _getId: function () {
+        var id = this.getAttribute('id');
+        if (!id) id = this.dataset.id;
+        return id;
+      },
+
+      _removeActive: function (items) {
+        for (var i = 0; i < items.length; i++) {
+          items[i].classList.remove('active');
+          items[i].setAttribute('aria-selected', "false");
         }
-      }.bind(this));
+      },
 
-      return queryResult;
-    }
+      _keydown: function () {
+        var items = this._getItems();
+        var length = items.length;
+        length--;
+        if (this._currentIndex < length) {
+          this._removeActive(items);
+          this._currentIndex++;
+          items[this._currentIndex].classList.add('active');
+          items[this._currentIndex].setAttribute('aria-selected', "true");
+          this._idElementHighlighted = items[this._currentIndex].id;
+          this._textOfHighlightedElement = this._suggestions[this._currentIndex][this.textProperty];
+          this._scroll(DIRECTION.DOWN);
+        }
+      },
 
-    /**
-     * Fired when a selection is made
-     *
-     * @event autocomplete-selected
-     * @param {String} id
-     * @param {String} text
-     * @param {Element} target
-     * @param {Object} option
-     */
+      _keyup: function () {
+        var items = this._getItems();
+        if (this._currentIndex > 0) {
+          this._removeActive(items);
+          this._currentIndex--;
+          items[this._currentIndex].classList.add('active');
+          items[this._currentIndex].setAttribute('aria-selected', "true");
+          this._idElementHighlighted = items[this._currentIndex].id;
+          this._textOfHighlightedElement = this._suggestions[this._currentIndex][this.textProperty];
+          this._scroll(DIRECTION.UP);
+        }
+      },
 
-    /**
-     * Fired on input change
-     *
-     * @event autocomplete-change
-     * @param {String} id
-     * @param {String} text
-     * @param {Element} target
-     * @param {Object} option
-     */
+      _keyenter: function () {
+        if (this.$.suggestionsWrapper.style.display == 'block' && this._currentIndex > -1) {
+          var index = this._currentIndex;
+          this._selection(index);
+        }
+      },
 
-    /**
-     * Fired on input focus
-     *
-     * @event autocomplete-focus
-     * @param {String} id
-     * @param {String} text
-     * @param {Element} target
-     * @param {Object} option
-     */
+      /**
+       * Move scroll (if needed) to display the active element in the suggestions list.
+       * @param {string} direction Direction to scroll. Possible values are `DIRECTION.UP` and `DIRECTION.DOWN`.
+       */
+      _scroll: function (direction) {
+        var modifier, isSelectedOutOfView;
 
-    /**
-     * Fired on input blur
-     *
-     * @event autocomplete-blur
-     * @param {String} id
-     * @param {String} text
-     * @param {Element} target
-     * @param {Object} option
-     */
+        var viewIndex = this._currentIndex - this._scrollIndex;
 
-    /**
-     * Fired on input reset/clear
-     *
-     * @event autocomplete-reset-blur
-     * @param {String} id
-     * @param {String} text
-     * @param {Element} target
-     * @param {Object} option
-     */
-  });
+        if (direction === DIRECTION.UP) {
+          modifier = -1;
+          isSelectedOutOfView = viewIndex < 0;
+        } else {
+          modifier = +1;
+          isSelectedOutOfView = viewIndex >= this._maxViewableItems
+        }
+
+        // Only when the current active element is out of view, we need to move the position of the scroll
+        if (isSelectedOutOfView) {
+          this._scrollIndex = this._scrollIndex + modifier;
+
+          var scrollTop = (this._scrollIndex * this._itemHeight);
+          var paperMaterial = this.querySelector('paper-material');
+          paperMaterial.scrollTop = scrollTop;
+        }
+      },
+
+      _fireEvent: function (option, evt) {
+        var id = this._getId();
+        var event = 'autocomplete' + this.eventNamespace + evt;
+
+        this.fire(event, {
+          id: id,
+          value: option[this.valueProperty] || option.value,
+          text: option[this.textProperty] || option.text,
+          target: this,
+          option: option
+        });
+      },
+
+      _onKeypress: function (event) {
+        var which = event.which;
+
+        if (which === 40) {
+          this._keydown();
+        } else if (which === 38) {
+          this._keyup(event);
+        } else if (which === 13) {
+          this._keyenter();
+        } else {
+          this._handleSuggestions(event);
+        }
+      },
+
+      _onSelect: function (event) {
+        var index = event.model.index;
+        this._selection(index);
+      },
+
+      _onBlur: function () {
+        var self = this;
+        var option = {
+          text: this.text,
+          value: this.value
+        };
+
+        this._fireEvent(option, 'blur');
+
+        setTimeout(function () {
+          self.$.clear.style.display = 'none';
+          self._hideSuggestionsWrapper();
+        }, 300);
+      },
+
+      _onFocus: function () {
+        var option = {
+          text: this.text,
+          value: this.value
+        };
+
+        this._fireEvent(option, 'focus');
+      },
+
+      /**
+       * Generate a suggestion id for a certain index
+       * @param {number} index Position of the element in the suggestions list
+       * @returns {string} a unique id based on the _idItemSeed and the position of that element in the suggestions popup
+       * @private
+       */
+      _getSuggestionId: function (index) {
+        return this._idItemSeed + '-' + index;
+      },
+
+      /**
+       * When item height is changed, the maxHeight of the suggestionWrapper need to be updated
+       */
+      _itemHeightChanged: function () {
+        this.$.suggestionsWrapper.style.maxHeight = this._itemHeight * this._maxViewableItems + 'px';
+      },
+
+      /****************************
+       * PUBLIC
+       ****************************/
+
+      /**
+       * Gets the current value of the input
+       * @returns {String}
+       */
+      getValue: function () {
+        return this.value;
+      },
+
+      /**
+       * Gets the current text/value option of the input
+       * @returns {Object}
+       */
+      getOption: function () {
+        return {
+          text: this.text,
+          value: this.value
+        };
+      },
+
+      /**
+       * Sets the current text/value option of the input
+       * @param {Object} option
+       */
+      setOption: function (option) {
+        this.text = option[this.textProperty || 'text'];
+        this.value = option[this.valueProperty || 'value'];
+      },
+
+      /**
+       * Disables the input
+       */
+      disable: function () {
+        this.disabled = true;
+        this.$.input.disabled = true;
+      },
+
+      /**
+       * Enables the input
+       */
+      enable: function () {
+        this.disabled = false;
+        this.$.input.disabled = false;
+      },
+
+      /**
+       * Sets the component's current suggestions
+       * @param {Array} arr
+       */
+      suggestions: function (arr) {
+        this._bindSuggestions(arr);
+      },
+
+      /**
+       * Validates the input
+       * @returns {Boolean}
+       */
+      validate: function () {
+        return this.$.input.validate();
+      },
+
+      /**
+       * Clears the current input
+       */
+      clear: function () {
+        this._value = '';
+        this._text = '';
+        this._clear();
+      },
+
+      /**
+       * Resets the current input
+       */
+      reset: function () {
+        this._clear();
+      },
+
+      /**
+       * Hides the suggestions popup
+       */
+      hideSuggestions: function () {
+        var self = this;
+
+        setTimeout(function () {
+          self.$.clear.style.display = 'none';
+          self._hideSuggestionsWrapper();
+        }, 300);
+      },
+
+      /**
+       * Query function is called on each keystroke to query the data source and returns the suggestions that matches
+       * with the filtering logic included.
+       * @param {Array} datasource An array containing all items before filtering
+       * @param {string} query Current value in the input field
+       * @returns {Array} an array containing only those items in the data source that matches the filtering logic.
+       */
+      queryFn: function (datasource, query) {
+        var queryResult = [];
+
+        datasource.forEach(function (item) {
+          var objText, objValue;
+
+          if (typeof item === 'object') {
+            objText = item[this.textProperty];
+            objValue = item[this.valueProperty]
+          } else {
+            objText = item.toString();
+            objValue = objText;
+          }
+
+          if (objText.toLowerCase().indexOf(query) === 0) {
+            // NOTE: the structure of the result object matches with the current template. For custom templates, you
+            // might need to return more data
+            queryResult.push({
+              text: objText,
+              value: objValue
+            });
+          }
+        }.bind(this));
+
+        return queryResult;
+      }
+
+      /**
+       * Fired when a selection is made
+       *
+       * @event autocomplete-selected
+       * @param {String} id
+       * @param {String} text
+       * @param {Element} target
+       * @param {Object} option
+       */
+
+      /**
+       * Fired on input change
+       *
+       * @event autocomplete-change
+       * @param {String} id
+       * @param {String} text
+       * @param {Element} target
+       * @param {Object} option
+       */
+
+      /**
+       * Fired on input focus
+       *
+       * @event autocomplete-focus
+       * @param {String} id
+       * @param {String} text
+       * @param {Element} target
+       * @param {Object} option
+       */
+
+      /**
+       * Fired on input blur
+       *
+       * @event autocomplete-blur
+       * @param {String} id
+       * @param {String} text
+       * @param {Element} target
+       * @param {Object} option
+       */
+
+      /**
+       * Fired on input reset/clear
+       *
+       * @event autocomplete-reset-blur
+       * @param {String} id
+       * @param {String} text
+       * @param {Element} target
+       * @param {Object} option
+       */
+    });
+  }());
 </script>

--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -421,6 +421,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this.templatize(this._suggestionTemplate);
     },
 
+    detached: function () {
+      this.cancelDebouncer('_onSuggestionChanged');
+    },
+
     listeners: {
       'input.focus': '_onFocus',
       'input.blur': '_onBlur'
@@ -555,21 +559,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * Listener to changes to _suggestions state
      */
     _onSuggestionsChanged: function () {
-      this._renderSuggestions(this._suggestions);
+      this.debounce('_onSuggestionChanged', function () {
+        this._renderSuggestions(this._suggestions);
 
-      if (this._suggestions.length > 0) {
-        this._showSuggestionsWrapper();
-      } else {
-        this._hideSuggestionsWrapper();
-      }
+        if (this._suggestions.length > 0) {
+          this._showSuggestionsWrapper();
+        } else {
+          this._hideSuggestionsWrapper();
+        }
 
-      Polymer.dom.flush();
+        Polymer.dom.flush();
 
-      var firstSuggestionElement = this.$.suggestionsWrapper.querySelector('paper-item');
-      if (firstSuggestionElement !== null) {
-        // Update maxHeight of suggestions wrapper depending on the height of each item result
-        this._itemHeight = firstSuggestionElement.offsetHeight;
-      }
+        var firstSuggestionElement = this.$.suggestionsWrapper.querySelector('paper-item');
+        if (firstSuggestionElement !== null) {
+          // Update maxHeight of suggestions wrapper depending on the height of each item result
+          this._itemHeight = firstSuggestionElement.offsetHeight;
+        }
+      }, 100);
     },
 
     _selection: function (index) {

--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -50,11 +50,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   ### Custom templates
   A template for each suggestion can be provided, but for now, there are limitations in the way you can customize
   the template. Please, read carefully all this section to know them.
-  In order to set your own template, you need to add a `<template>` tag with the following structure:
+  In order to set your own template, you need to add a `<template>` tag with the attribute
+  `autocomplete-custom-template` ahd the following structure:
 
   ```
   <paper-autocomplete>
-    <template>
+    <template autocomplete-custom-template>
       <div on-tap="_onSelect">
         <paper-item id$="[[_getSuggestionId(index)]]" role="option" aria-selected="false">
           YOUR CUSTOM TEMPLATE
@@ -219,7 +220,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
 
     <!-- Custom template -->
-    <content id="templates" select="template"></content>
+    <content id="templates" select="[autocomplete-custom-template]"></content>
   </template>
 </dom-module>
 

--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -136,7 +136,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                    char-counter$="[[charCounter]]"
                    maxlength$="[[maxlength]]"
 
-                   role="textbox" aria-autocomplete="list"
+                   role="textbox"
+                   aria-autocomplete="list"
                    aria-multiline="false"
                    aria-activedescendant$="[[_idElementHighlighted]]"
                    aria-disabled$="[[disabled]]"
@@ -145,6 +146,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <paper-icon-button id="clear" icon="clear" on-click="_clear"></paper-icon-button>
 
       <!-- to announce current selection to screen reader -->
+      <!-- TODO: test this with complex custom templates -->
       <span id="autocompleteStatus" role="status" class="sr-only">[[_textOfHighlightedElement]]</span>
     </div>
 
@@ -527,6 +529,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       } else {
         this.$.clear.style.display = 'none';
         this._suggestions = [];
+        this._renderSuggestions(this._suggestions);
       }
     },
 

--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -31,6 +31,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   You can override this behavior providing your own query function, as long as these two requirements are fulfill:
   - The query function is synchronous.
   - The API is respected and the method always return an Array.
+  The template use to render each suggestion depends on the structure of each object that this method returns. For the
+  default template, each suggestion should follow this object structure:
+  ```
+    {
+      text: objText,
+      value: objValue
+    }
+  ```
 
   ### Styling
 
@@ -51,6 +59,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       display: block;
       box-sizing: border-box;
       position: relative;
+
+      --paper-input-container-focus-color: #2196f3;
+      --paper-item-min-height: 36px;
     }
 
     .input-wrapper {
@@ -74,18 +85,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     :host[suggestions-in-overlay="true"] #suggestionsWrapper {
     }
 
-    paper-item {
+    :host ::content paper-item {
       position: relative;
       line-height: 18px;
     }
 
-    paper-item:hover {
+    :host ::content paper-item:hover {
       background: #eee;
       color: #333;
       cursor: pointer;
     }
 
-    paper-item.active {
+    :host ::content paper-item.active {
       background: #eee;
       color: #333;
     }
@@ -93,11 +104,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     #clear {
       display: none;
       margin-top: auto;
-    }
-
-    :host {
-      --paper-input-container-focus-color: #2196f3;
-      --paper-item-min-height: 36px;
     }
 
     .sr-only {
@@ -141,20 +147,34 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <!-- to announce current selection to screen reader -->
       <span id="autocompleteStatus" role="status" class="sr-only">[[_textOfHighlightedElement]]</span>
     </div>
+
     <paper-material elevation="1" id="suggestionsWrapper" role="listbox">
-      <template is="dom-repeat" items="{{_suggestions}}">
-        <paper-item on-click="_onSelect" id$="[[_getSuggestionId(index)]]" role="option" aria-selected="false">
-          <div>{{_getItemText(item)}}</div>
+      <!-- suggestions will be render here -->
+    </paper-material>
+
+    <!-- Default suggestion template -->
+    <template id="defaultTemplate">
+      <div on-tap="_onSelect">
+        <paper-item id$="[[_getSuggestionId(index)]]" role="option" aria-selected="false">
+          <div>[[_getItemText(item)]]</div>
           <paper-ripple></paper-ripple>
         </paper-item>
-      </template>
-    </paper-material>
+      </div>
+    </template>
+
+    <!-- Custom template -->
+    <content id="templates" select="template"></content>
   </template>
 </dom-module>
 
 <script>
   Polymer({
     is: 'paper-autocomplete',
+
+    behaviors: [
+      Polymer.Templatizer
+    ],
+
     properties: {
       /**
        * `autoValidate` Set to true to auto-validate the input value.
@@ -303,6 +323,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       /**
+       * Reference to the current suggestion template
+       */
+      _suggestionTemplate: {
+        type: Object,
+        value: function () {
+          var customTemplate = this.getEffectiveChildren();
+
+          return customTemplate.length > 0 ? customTemplate[0] : this.$.defaultTemplate;
+        }
+      },
+
+      /**
        * `_suggestions` Array with the actual suggestions to display
        */
       _suggestions: Array,
@@ -370,6 +402,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     ready: function () {
       this._value = this.value;
+
+      // This is important to be able to access component methods inside the templates used with Templatizer
+      this.dataHost = this;
+
+      // templatize must be called once before stamp is called
+      this.templatize(this._suggestionTemplate);
     },
 
     listeners: {
@@ -435,14 +473,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     _remoteSuggestions: function (event) {
       var value = event.target.value;
-      var minLength = this.minLength;
       var option = {
         text: this.text,
         value: value
       };
 
-      if (value && value.length >= minLength) {
+      if (value && value.length >= this.minLength) {
         this._fireEvent(option, 'change');
+        this._renderSuggestions(this._suggestions);
       } else {
         this.$.clear.style.display = 'none';
         this._suggestions = [];
@@ -478,6 +516,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // Call queryFn. User can override queryFn() to provide custom search functionality
           this._suggestions = this.queryFn(this.source, value);
 
+          this._renderSuggestions(this._suggestions);
+
           if (this._suggestions.length > 0) {
             this._showSuggestionsWrapper();
           } else {
@@ -488,6 +528,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.$.clear.style.display = 'none';
         this._suggestions = [];
       }
+    },
+
+    /**
+     * Render suggestions in the suggestionsWrapper container
+     * @param {Array} suggestions An array containing the suggestions to be rendered. This value is not optional, so
+     *    in case no suggestions need to be rendered, you should either not call this method or provide an empty array.
+     */
+    _renderSuggestions: function (suggestions) {
+      var suggestionsContainer = this.$.suggestionsWrapper;
+
+      suggestionsContainer.innerHTML = '';
+
+      suggestions.forEach(function (result, index) {
+        // clone the template and bind with the model
+        var clone = this.stamp({
+          item: result,
+          index: index
+        });
+
+        suggestionsContainer.appendChild(clone.root);
+      }.bind(this));
     },
 
     _selection: function (index) {
@@ -764,8 +825,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
 
         if (objText.toLowerCase().indexOf(query) === 0) {
-          // Adds the item to the suggestions list.
-          queryResult.push({text: objText, value: objValue});
+          // NOTE: the structure of the result object matches with the current template. For custom templates, you
+          // might need to return more data
+          queryResult.push({
+            text: objText,
+            value: objValue
+          });
         }
       }.bind(this));
 

--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -24,6 +24,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   paper-autocomplete extends earlier efforts such as this (https://github.com/rodo1111/paper-input-autocomplete)
   to provide keyboard support, remote binding and results scrolling.
 
+  It is **important to provide both `textProperty` and `valueProperty` when working with a custom search function and
+  or custom templates.** They are needed to keep the component accessible and for the events (e.g. onSelect) to keep
+  working.
+
   ### Custom search
   This component has the public method `queryFn` that is called in each key stroke and it is responsible to query
   all items in the `source` and returns only those items that matches certain filtering criteria. By default, this
@@ -39,6 +43,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       value: objValue
     }
   ```
+
+  This function is only used when a local data source is used. When using a `remoteDataSource` user is responsible of
+  doing the search and specify suggestions manually.
 
   ### Custom templates
   A template for each suggestion can be provided, but for now, there are limitations in the way you can customize

--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -831,8 +831,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @param {Object} option
        */
       setOption: function (option) {
-        this.text = option[this.textProperty || 'text'];
-        this.value = option[this.valueProperty || 'value'];
+        this.text = option[this.textProperty] || option.text;
+        this.value = option[this.valueProperty] || option.value;
       },
 
       /**

--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -40,6 +40,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
   ```
 
+  ### Custom templates
+  TODO: document elements should have min height issue.
+  TODO: document wrapper
+  TODO: need to use textProperty and valueProperty for A11Y
+
   ### Styling
 
   `<paper-autocomplete>` provides the following custom properties and mixins
@@ -146,7 +151,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <paper-icon-button id="clear" icon="clear" on-click="_clear"></paper-icon-button>
 
       <!-- to announce current selection to screen reader -->
-      <!-- TODO: test this with complex custom templates -->
       <span id="autocompleteStatus" role="status" class="sr-only">[[_textOfHighlightedElement]]</span>
     </div>
 
@@ -617,7 +621,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         items[this._currentIndex].classList.add('active');
         items[this._currentIndex].setAttribute('aria-selected', "true");
         this._idElementHighlighted = items[this._currentIndex].id;
-        this._textOfHighlightedElement = this._suggestions[this._currentIndex].text;
+        this._textOfHighlightedElement = this._suggestions[this._currentIndex][this.textProperty];
         this._scroll('down');
       }
     },
@@ -630,7 +634,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         items[this._currentIndex].classList.add('active');
         items[this._currentIndex].setAttribute('aria-selected', "true");
         this._idElementHighlighted = items[this._currentIndex].id;
-        this._textOfHighlightedElement = this._suggestions[this._currentIndex].text;
+        this._textOfHighlightedElement = this._suggestions[this._currentIndex][this.textProperty];
         this._scroll('up');
       }
     },

--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -605,7 +605,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         items[this._currentIndex].setAttribute('aria-selected', "true");
         this._idElementHighlighted = items[this._currentIndex].id;
         this._textOfHighlightedElement = this._suggestions[this._currentIndex].text;
-        this._scrollDown();
+        this._scroll('down');
       }
     },
 
@@ -618,7 +618,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         items[this._currentIndex].setAttribute('aria-selected', "true");
         this._idElementHighlighted = items[this._currentIndex].id;
         this._textOfHighlightedElement = this._suggestions[this._currentIndex].text;
-        this._scrollUp();
+        this._scroll('up');
       }
     },
 
@@ -629,25 +629,33 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     },
 
-    _scrollDown: function () {
+    /**
+     * Move scroll (if needed) to display the active element in the suggestions list.
+     * @param {string} direction Direction to scroll. Possible values are `'up'` and `'down'`.
+     */
+    _scroll: function (direction) {
+      var modifier, isSelectedOutOfView;
+
       var viewIndex = this._currentIndex - this._scrollIndex;
-      if (viewIndex >= this._maxViewableItems) {
-        this._scrollIndex++;
+
+      if (direction === 'up') {
+        modifier = -1;
+        isSelectedOutOfView = viewIndex < 0;
+      } else {
+        modifier = +1;
+        isSelectedOutOfView = viewIndex >= this._maxViewableItems
+      }
+
+      // Only when the current active element is out of view, we need to move the position of the scroll
+      if (isSelectedOutOfView) {
+        this._scrollIndex = this._scrollIndex + modifier;
+
         var scrollTop = (this._scrollIndex * this._itemHeight);
         var paperMaterial = this.querySelector('paper-material');
         paperMaterial.scrollTop = scrollTop;
       }
     },
 
-    _scrollUp: function () {
-      var viewIndex = this._currentIndex - this._scrollIndex;
-      if (viewIndex < 0) {
-        this._scrollIndex--;
-        var scrollTop = (this._scrollIndex * this._itemHeight);
-        var paperMaterial = this.querySelector('paper-material');
-        paperMaterial.scrollTop = scrollTop;
-      }
-    },
     _fireEvent: function (option, evt) {
       var id = this._getId();
       var event = 'autocomplete' + this.eventNamespace + evt;

--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -825,8 +825,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @param {Object} option
      */
     setOption: function (option) {
-      this.text = option.text;
-      this.value = option.value;
+      this.text = option[this.textProperty || 'text'];
+      this.value = option[this.valueProperty || 'value'];
     },
 
     /**

--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -563,6 +563,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this._hideSuggestionsWrapper();
       }
 
+      Polymer.dom.flush();
+
       var firstSuggestionElement = this.$.suggestionsWrapper.querySelector('paper-item');
       if (firstSuggestionElement !== null) {
         // Update maxHeight of suggestions wrapper depending on the height of each item result


### PR DESCRIPTION
## Release 2.0.0 (2016-11-21)

### New Features
- It is now possible to specify custom templates for suggestions.
- You can now specify your own `queryFn` to filter suggestions according to your needs.
- Added `CHANGELOG.md`

### Breaking Change
- Property `useShadowDom` has been removed because now the component works in both modes without it. You can just remove
  it from your apps. However, if you have it, nothing will break, it will just be ignored.
  
### Bug Fixes
- `setOption()` method was not taking into account `textProperty` and `valueProperty` options.
