### PR TITLE
set primary-color as default focus color

### DIFF
--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -89,7 +89,7 @@
 
   Custom property | Description | Default
   ----------------|-------------|----------
-  `--paper-input-container-focus-color` | sets the components input container focus color | #2196f3
+  `--paper-input-container-focus-color` | sets the components input container focus color | var(--primary-color)
   `--paper-item-min-height` | paper item min height | `36px`
   `--suggestions-container` | mixin to apply to the suggestions container | `{}`
 
@@ -106,7 +106,7 @@
       display: block;
       box-sizing: border-box;
       position: relative;
-      --paper-input-container-focus-color: #2196f3;
+      --paper-input-container-focus-color: var(--primary-color);
     }
 
     .input-wrapper {


### PR DESCRIPTION
Added --paper-input-container-focus-color: var(--primary-color); 
For issue #51