### PR TITLE
Fix textProperty in  _getItemText method

### DIFF
--- a/paper-autocomplete-suggestions.html
+++ b/paper-autocomplete-suggestions.html
@@ -441,7 +441,7 @@
        * @return {String}
        */
       _getItemText: function (suggestion) {
-        return suggestion[this.textProperty];
+        return suggestion["text"];
       },
 
       /**


### PR DESCRIPTION
When i used custom textProperty, method _getItemText return undefined, because input array transformed to array like [text: "", value: ""]