### PR TITLE
Move dev dependencies to appropriate list

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -36,14 +36,14 @@
     "iron-iconset-svg": "polymerelements/iron-iconset-svg#^1.0.0",
     "paper-item": "polymerelements/paper-item#^1.0.0",
     "paper-ripple": "polymerelements/paper-ripple#^1.0.0",
-    "paper-material": "polymerelements/paper-material#^1.0.0",
-    "mocha": "^3.1.2",
-    "chai": "^3.5.0",
-    "sinon": "^1.17.6"
+    "paper-material": "polymerelements/paper-material#^1.0.0"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "web-component-tester": "*",
+    "mocha": "^3.1.2",
+    "chai": "^3.5.0",
+    "sinon": "^1.17.6",
     "iron-demo-helpers": "^1.2.5",
     "paper-toast": "^1.3.0",
     "elliptical-sass": "^1.2.29",


### PR DESCRIPTION
At least `mocha`, `chai` and `sinon` are devDependencies. Maybe some others. Needs some investigation, so let's do it in this Pull Request.