### PR TITLE
WIP: Allow rendering the suggestion results with HTML

### DIFF
--- a/paper-autocomplete-suggestions.html
+++ b/paper-autocomplete-suggestions.html
@@ -171,7 +171,7 @@
       <!-- Default suggestion template -->
       <template id="defaultTemplate">
         <paper-item id$="[[_getSuggestionId(index)]]" role="option" aria-selected="false" on-tap="_onSelect">
-          <div>[[_getItemText(item)]]</div>
+          <div inner-h-t-m-l="[[item.text]]"></div>
           <paper-ripple></paper-ripple>
         </paper-item>
       </template>
@@ -448,15 +448,6 @@
       },
 
       // Element Behavior
-
-      /**
-       * Get the text property from the suggestion
-       * @param {Object} suggestion The suggestion item
-       * @return {String}
-       */
-      _getItemText: function (suggestion) {
-        return suggestion[this.textProperty];
-      },
 
       /**
        * Show the suggestions wrapper


### PR DESCRIPTION
This is compatible with rendering text but also enables the `queryFn` to highlight the result text in the result.

For example:

```js
  item.text = item.text.replace(new RegExp('(' + query + ')', 'ig'), '<b>$1</b>');
```

Also, since the property to render is controlled by the `queryFn`, and the default `queryFn` returns hardcoded 'text', use the same property here.
This fixes the bug of using a custom `textProperty` which now renders empty results.