### PR TITLE
Return a reference to the original item in query results

### DIFF
--- a/paper-autocomplete-suggestions.html
+++ b/paper-autocomplete-suggestions.html
@@ -900,6 +900,7 @@
             // NOTE: the structure of the result object matches with the current template. For custom templates, you
             // might need to return more data
             queryResult.push({
+              item: item,
               text: objText,
               value: objValue
             });


### PR DESCRIPTION
When supplying complex objects as items, the handling of the results
will most likely result in some kind of lookup in an object list to
find the right object corresponding to the `value` in the results.

For all those cases, it would be a lot more convenient and performant
to actually get a reference to the original object in the result.

This would allow object instance comparison such as:

```js
arrayOfObject.indexOf(result.item) === -1
```