### PR TITLE
Default to item object as value if valueProperty isn't truthy

### DIFF
--- a/paper-autocomplete-suggestions.html
+++ b/paper-autocomplete-suggestions.html
@@ -890,7 +890,11 @@
 
           if (typeof item === 'object') {
             objText = item[this.textProperty];
-            objValue = item[this.valueProperty];
+            if (this.valueProperty) {
+              objValue = item[this.valueProperty];
+            } else {
+              objValue = item;
+            }
           } else {
             objText = item.toString();
             objValue = objText;


### PR DESCRIPTION
Adjust default queryFn to return the relevant object instead of a value property if the valueProperty property is falsy.