### PR TITLE
Avoid horizontal scroll in suggestions

### DIFF
--- a/paper-autocomplete-suggestions.html
+++ b/paper-autocomplete-suggestions.html
@@ -124,7 +124,7 @@
       paper-material {
         display: none;
         position: absolute;
-        width: 100%;
+        min-width: 100%;
         z-index: 1000;
         background-color: white;
         max-height: 252px;
@@ -139,6 +139,7 @@
         padding: 0 16px;
         position: relative;
         line-height: 18px;
+        white-space: nowrap;
       }
 
       paper-item:hover,


### PR DESCRIPTION
When having a small input with long label suggestions, the list gets
scrolling both up/down and sideways.

These CSS changes allows the suggestion list to be wider than the input
if needed, but remains the same width if it's enough.