### PR TITLE
suggestion list not working properly if text-property oder value-property not has default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This component follows *Semantic Versioning* (aka SemVer), visit (http://semver.org/) to learn more about it.
 
+## Release 3.4.1 (2018-01-23)
+### Bug Fixes
+- Suggestion list will now work properly if text-property or value-property not set to default value. Fixes #66 and #103
+
 ## Release 3.4.0 (2017-10-28)
 ### New Features
 - Component now exposes `readOnly` option.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "paper-autocomplete",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "authors": [
     "S. Francis",
     "Rodolfo Oviedo <rodo1111@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "paper-autocomplete",
   "description": "Material Design autocomplete component.",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "author": "S. Francis <sfrancis@misinteractive.com>",
   "contributors": [
     "Rodolfo Oviedo <rodo1111@gmail.com>",

--- a/paper-autocomplete-suggestions.html
+++ b/paper-autocomplete-suggestions.html
@@ -918,10 +918,10 @@
           if (objText.toLowerCase().indexOf(query) === 0) {
             // NOTE: the structure of the result object matches with the current template. For custom templates, you
             // might need to return more data
-            queryResult.push({
-              text: objText,
-              value: objValue
-            });
+            var resultItem = {};
+            resultItem[this.textProperty] = objText;
+            resultItem[this.valueProperty] = objValue;
+            queryResult.push(resultItem);
           }
         }.bind(this));
 

--- a/test/index.html
+++ b/test/index.html
@@ -19,6 +19,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       WCT.loadSuites([
         'paper-autocomplete_test_local.html',
         'paper-autocomplete_test_local.html?dom=shadow',
+        'paper-autocomplete_test_local_customsource.html',
+        'paper-autocomplete_test_local_customsource.html?dom=shadow',
         'paper-autocomplete_test_multi.html',
         'paper-autocomplete_test_multi.html?dom=shadow'
       ]);

--- a/test/paper-autocomplete_test_local_customsource.html
+++ b/test/paper-autocomplete_test_local_customsource.html
@@ -1,0 +1,412 @@
+<!doctype html>
+
+<html>
+
+<head>
+  <title>Paper-autocomplete test</title>
+  <meta charset='utf-8'>
+  <meta name='viewport' content='width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes'>
+  <script src='../../webcomponentsjs/webcomponents-lite.js'></script>
+  <script src='../../web-component-tester/browser.js'></script>
+  <script src='../../iron-test-helpers/mock-interactions.js'></script>
+  <link rel='import' href='../paper-autocomplete.html'>
+</head>
+
+<body>
+  <test-fixture id='basic'>
+    <template>
+      <paper-autocomplete
+        label='Select State'
+        id='input-local'
+        no-label-float
+        required
+        name='state'
+        value-property="code"
+        text-property="titel">
+      </paper-autocomplete>
+  </template>
+  </test-fixture>
+
+  <test-fixture id='suffixTest'>
+    <template>
+      <paper-autocomplete
+        id='suffix'
+        name='state'>
+          <button slot="suffix" suffix id='suffixBtn'>OK</button>
+      </paper-autocomplete>
+    </template>
+  </test-fixture>
+
+  <script>
+    describe('paper-autocomplete', function () {
+      var element, states;
+
+      beforeEach(function (done) {
+        element = fixture('basic');
+
+        states = [
+          {'titel': 'Alabama', 'code': 'AL'},
+          {'titel': 'Alaska', 'code': 'AK'},
+          {'titel': 'American Samoa', 'code': 'AS'},
+          {'titel': 'Arizona', 'code': 'AZ'},
+          {'titel': 'Arkansas', 'code': 'AR'},
+          {'titel': 'California', 'code': 'CA'},
+          {'titel': 'Colorado', 'code': 'CO'},
+          {'titel': 'Connecticut', 'code': 'CT'},
+          {'titel': 'Delaware', 'code': 'DE'},
+          {'titel': 'District Of Columbia', 'code': 'DC'},
+          {'titel': 'Federated States Of Micronesia', 'code': 'FM'},
+          {'titel': 'Florida', 'code': 'FL'},
+          {'titel': 'Georgia', 'code': 'GA'},
+          {'titel': 'Guam', 'code': 'GU'},
+          {'titel': 'Hawaii', 'code': 'HI'},
+          {'titel': 'Idaho', 'code': 'ID'},
+          {'titel': 'Illinois', 'code': 'IL'},
+          {'titel': 'Indiana', 'code': 'IN'},
+          {'titel': 'Iowa', 'code': 'IA'},
+          {'titel': 'Kansas', 'code': 'KS'},
+          {'titel': 'Kentucky', 'code': 'KY'},
+          {'titel': 'Louisiana', 'code': 'LA'},
+          {'titel': 'Maine', 'code': 'ME'},
+          {'titel': 'Marshall Islands', 'code': 'MH'},
+          {'titel': 'Maryland', 'code': 'MD'},
+          {'titel': 'Massachusetts', 'code': 'MA'},
+          {'titel': 'Michigan', 'code': 'MI'},
+          {'titel': 'Minnesota', 'code': 'MN'},
+          {'titel': 'Mississippi', 'code': 'MS'},
+          {'titel': 'Missouri', 'code': 'MO'},
+          {'titel': 'Montana', 'code': 'MT'},
+          {'titel': 'Nebraska', 'code': 'NE'},
+          {'titel': 'Nevada', 'code': 'NV'},
+          {'titel': 'New Hampshire', 'code': 'NH'},
+          {'titel': 'New Jersey', 'code': 'NJ'},
+          {'titel': 'New Mexico', 'code': 'NM'},
+          {'titel': 'New York', 'code': 'NY'},
+          {'titel': 'North Carolina', 'code': 'NC'},
+          {'titel': 'North Dakota', 'code': 'ND'},
+          {'titel': 'Northern Mariana Islands', 'code': 'MP'},
+          {'titel': 'Ohio', 'code': 'OH'},
+          {'titel': 'Oklahoma', 'code': 'OK'},
+          {'titel': 'Oregon', 'code': 'OR'},
+          {'titel': 'Palau', 'code': 'PW'},
+          {'titel': 'Pennsylvania', 'code': 'PA'},
+          {'titel': 'Puerto Rico', 'code': 'PR'},
+          {'titel': 'Rhode Island', 'code': 'RI'},
+          {'titel': 'South Carolina', 'code': 'SC'},
+          {'titel': 'South Dakota', 'code': 'SD'},
+          {'titel': 'Tennessee', 'code': 'TN'},
+          {'titel': 'Texas', 'code': 'TX'},
+          {'titel': 'Utah', 'code': 'UT'},
+          {'titel': 'Vermont', 'code': 'VT'},
+          {'titel': 'Virgin Islands', 'code': 'VI'},
+          {'titel': 'Virginia', 'code': 'VA'},
+          {'titel': 'Washington', 'code': 'WA'},
+          {'titel': 'West Virginia', 'code': 'WV'},
+          {'titel': 'Wisconsin', 'code': 'WI'},
+          {'titel': 'Wyoming', 'code': 'WY'}
+        ];
+
+        element.source = states;
+
+        done();
+      });
+
+      it('instantiates a paper-autocomplete element', function () {
+        expect(element.is).to.equal('paper-autocomplete');
+      });
+
+      it('has a label Select State', function () {
+        var label = element.$$('label');
+        expect(label.textContent).to.equal('Select State');
+      });
+
+      it('copies the required property to the input field', function () {
+        var input = element.$.autocompleteInput;
+        expect(input.required).to.equal(element.required);
+      });
+
+      it('loads the list of sources', function () {
+        expect(element.source).to.equal(states);
+      });
+
+      it('is closed when initialised', function () {
+        expect(element.$.paperAutocompleteSuggestions.$.suggestionsWrapper.style.display).to.not.equal('block');
+      });
+
+      it('should set the name attribute in the hidden input', function () {
+        expect(element.$$('input[type="hidden"]').getAttribute('name')).to.equal('state');
+      });
+
+      describe('when input is typed', function () {
+        var input, suggestions, suggestionItems;
+
+        beforeEach(function () {
+          input = element.$.autocompleteInput;
+          suggestions = element.$.paperAutocompleteSuggestions.$.suggestionsWrapper;
+        });
+
+        it('opens', function () {
+          enterCharacter(input, 'A');
+          suggestionItems = suggestions.querySelectorAll('paper-item');
+
+          expect(suggestionItems.length).to.equal(5);
+        });
+
+        it('does not activate an item on opening', function () {
+          enterCharacter(input, 'A');
+
+          var activeSuggestion = suggestions.querySelector('paper-item.active');
+          expect(activeSuggestion).to.equal(null);
+        });
+
+        it('refines the suggestions with every added key', function () {
+          enterCharacter(input, 'A');
+          enterCharacter(input, 'l');
+
+          suggestionItems = suggestions.querySelectorAll('paper-item');
+          expect(suggestionItems.length).to.equal(2);
+        });
+
+        it('show labels in suggestion list', function () {
+          enterCharacter(input, 'A');
+          enterCharacter(input, 'l');
+
+          suggestionItems = suggestions.querySelectorAll('paper-item');
+
+          expect(suggestionItems.length).to.equal(2);
+          expect(suggestionItems[0].children[0].innerText).to.equal('Alabama');
+          expect(suggestionItems[1].children[0].innerText).to.equal('Alaska');
+        });
+
+        it('selects the next and previous suggestions with arrow keys', function () {
+          enterCharacter(input, 'A');
+
+          var suggestionItems = suggestions.querySelectorAll('paper-item');
+
+          MockInteractions.keyUpOn(input, 40);
+          expect(activeSuggestion()).to.equal(suggestionItems[0]);
+
+          MockInteractions.keyUpOn(input, 40);
+          expect(activeSuggestion()).to.equal(suggestionItems[1]);
+
+          MockInteractions.keyUpOn(input, 38);
+          expect(activeSuggestion()).to.equal(suggestionItems[0]);
+
+          function activeSuggestion() {
+            return suggestions.querySelector('paper-item.active');
+          }
+        });
+
+        it('copies the suggestion to the value when clicked upon a suggestion and closes the suggestions', function (done) {
+          enterCharacter(input, 'A');
+          var suggestionItems = suggestions.querySelectorAll('paper-item');
+
+          suggestionItems[0].click();
+          expect(input.value).to.equal('Alabama');
+
+          Polymer.dom.flush();
+
+          setTimeout(function () {
+            expect(element.$.paperAutocompleteSuggestions.$.suggestionsWrapper.style.display).to.equal('none');
+            done();
+          }, 300);
+        });
+
+        it('sets value and text in autocomplete when a selection is made', function () {
+          enterCharacter(input, 'A');
+          var suggestionItems = suggestions.querySelectorAll('paper-item');
+
+          suggestionItems[0].click();
+
+          expect(element.text).to.equal('Alabama');
+          expect(element.value).to.equal('AL');
+
+          // On selection, the hidden input field should have set the value, not the text
+          expect(element.$$('input[type="hidden"]').value).to.equal('AL');
+        });
+
+        describe('and after showing results', function () {
+          describe('when the autosuggest is closed', function () {
+            it('should clear previous results from the dom', function (done) {
+              enterCharacter(input, 'A');
+              var suggestionItems = suggestions.querySelectorAll('paper-item');
+
+              suggestionItems[0].click();
+
+              setTimeout(function () {
+                expect(suggestions.querySelectorAll('paper-item').length).to.equal(0);
+                done();
+              }, 300);
+            });
+          });
+        });
+
+        describe('the "disableShowClear" option should disable showing the clear X button', function () {
+
+          var input,
+            displayStyle;
+
+          var doInput = function (input, inputText) {
+            enterCharacter(input, inputText);
+            element._textObserver(inputText); // trigger an onInput event which in turn evaluates whether to display the button
+          };
+
+          beforeEach(function () {
+            input = element.$.autocompleteInput;
+          });
+
+          it('should disable the display of the clear button when the attribute is on the element', function () {
+            element.setAttribute('disable-show-clear', '');
+
+            doInput(input, 'Ne');
+            displayStyle = getClearButtonDisplayStyle();
+            expect(displayStyle).to.equal('');
+          });
+
+          it('should display of the clear button when the option is set to false (default)', function () {
+            doInput(input, 'New');
+            displayStyle = getClearButtonDisplayStyle();
+            expect(displayStyle).to.equal('inline-block');
+          });
+        });
+      });
+
+      describe('hideSuggestions()', function () {
+        var input;
+
+        beforeEach(function () {
+          input = element.$.autocompleteInput;
+        });
+
+        var doInput = function (input, inputText) {
+          enterCharacter(input, inputText);
+          element._textObserver(inputText); // trigger an onInput event which in turn evaluates whether to display the button
+        };
+
+        it('should hide the suggestion wrapper and clear button', function (done) {
+          doInput(input, 'A');
+
+          expect(element.$.paperAutocompleteSuggestions.$.suggestionsWrapper.style.display).to.equal('block');
+          expect(getClearButtonDisplayStyle()).to.equal('inline-block');
+
+          element.hideSuggestions();
+
+          Polymer.dom.flush();
+
+          setTimeout(function () {
+            expect(element.$.paperAutocompleteSuggestions.$.suggestionsWrapper.style.display).to.equal('none');
+            expect(getClearButtonDisplayStyle()).to.equal('none');
+
+            done();
+          }, 300);
+        });
+      });
+
+      describe('_clear()', function () {
+        beforeEach(function () {
+          element.value = 'AL';
+          element.text = 'Alabama';
+        });
+
+        it('should reset the content of the autocomplete', function () {
+          element._clear();
+
+          expect(element.value).to.be.null;
+          expect(element.text).to.equal('');
+        });
+
+        it('should hide the clear button', function () {
+          element.$.clear.style.display = 'block';
+          element._isClearButtonVisible = true;
+
+          element._clear();
+
+          expect(element.$.clear.style.display).to.equal('none');
+        });
+
+        it('should fire the correct event', function (done) {
+          element.addEventListener('autocomplete-reset-blur', function (event) {
+            expect(event.type).to.equal('autocomplete-reset-blur');
+            done();
+          });
+
+          element._clear();
+        });
+      });
+
+      it('element with slot=preffix should be added as paper-input suffix', function () {
+        var suffixElement = fixture('suffixTest');
+        var children = Polymer.dom(suffixElement.$$('paper-input').$$('paper-input-container')).getEffectiveChildNodes();
+        var isSuffixBtnAdded = [].slice.call(children)
+          .filter(function (ele) {
+            return ele.id === 'suffixBtn';
+          }).length === 1;
+
+        expect(isSuffixBtnAdded).to.be.true;
+      });
+
+      describe('autocomplete option', function () {
+        it('if set to `true`, it should highlight always the first suggestion', function () {
+          element.setAttribute('highlight-first', '');
+
+          var suggestions = element.$.paperAutocompleteSuggestions.$.suggestionsWrapper;
+          var input = element.$.autocompleteInput;
+
+          enterCharacter(input, 'A');
+
+          var activeSuggestions = suggestions.querySelectorAll('paper-item.active');
+          var allSuggestions = suggestions.querySelectorAll('paper-item');
+
+          expect(allSuggestions).not.to.be.empty;
+          expect(activeSuggestions.length).to.equal(1);
+          expect(activeSuggestions[0]).to.equal(allSuggestions[0]);
+        });
+
+        it('with default value, it should not highlight the first suggestion', function () {
+          var suggestions = element.$.paperAutocompleteSuggestions.$.suggestionsWrapper;
+          var input = element.$.autocompleteInput;
+
+          enterCharacter(input, 'A');
+
+          var activeSuggestions = suggestions.querySelectorAll('paper-item.active');
+          var allSuggestions = suggestions.querySelectorAll('paper-item');
+
+          expect(allSuggestions).not.to.be.empty;
+          expect(activeSuggestions.length).to.equal(0);
+        });
+      });
+
+      describe('when element is focused', function () {
+        beforeEach(function () {
+          element.showResultsOnFocus = true;
+          sinon.stub(element.$.paperAutocompleteSuggestions, '_handleSuggestions');
+        });
+
+        it('should call _handleSuggestions', function () {
+          var event = {};
+          element.$.paperAutocompleteSuggestions._onFocus(event);
+
+          expect(element.$.paperAutocompleteSuggestions._handleSuggestions.calledWith(event)).to.be.true;
+        });
+      });
+
+      a11ySuite('basic', ['badAriaAttributeValue', 'nonExistentRelatedElement']);
+
+      // HELPERS
+
+      function enterCharacter(input, char) {
+        input.value += char;
+        MockInteractions.keyUpOn(input, char.charCodeAt(char.length - 1));
+
+        element.$.paperAutocompleteSuggestions.flushDebouncer('_onSuggestionChanged');
+      }
+
+      function getClearButtonDisplayStyle() {
+        return element.$.clear.style.display;
+      }
+    });
+  </script>
+
+</body>
+
+</html>


### PR DESCRIPTION
This PR can fix #66 and #103. Function `queryFn` remap the result items to default behavior of text-property="text" and value-property="value". result item now creates item depend on text-, value-property. Unit Test added.