### PR TITLE
Expose the 'disabled' property

### DIFF
--- a/paper-autocomplete.html
+++ b/paper-autocomplete.html
@@ -304,6 +304,14 @@
         },
 
         /**
+         * `disabled` Set to true to mark the input as disabled.
+         */
+        disabled: {
+          type: Boolean,
+          value: false
+        },
+
+        /**
          * `source` Array of objects with the options to execute the autocomplete feature
          */
         source: {


### PR DESCRIPTION
The `disabled` property is bound to `paper-input` but not exposed to the element's property.

See also https://github.com/ellipticaljs/paper-autocomplete/issues/96
Ref https://github.com/Neovici/paper-autocomplete-chips/issues/8
Ref https://github.com/Neovici/paper-autocomplete-chips/pull/10